### PR TITLE
Fix sum_dirac_dfcoef command, Add Open with sum_dirac_dfcoef output option

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,1 +1,2 @@
+!Ar_Ar.out
 !x2c_uo2_238.out

--- a/data/Ar_Ar.out
+++ b/data/Ar_Ar.out
@@ -1,0 +1,4833 @@
+[1667967651.726922] [relqc01:3882146:0]      rdmacm_cm.c:638  UCX  ERROR rdma_create_event_channel failed: No such device
+[1667967651.726935] [relqc01:3882146:0]     ucp_worker.c:1434 UCX  ERROR failed to open CM on component rdmacm with status Input/output error
+[1667967651.726936] [relqc01:3882147:0]      rdmacm_cm.c:638  UCX  ERROR rdma_create_event_channel failed: No such device
+[1667967651.726946] [relqc01:3882147:0]     ucp_worker.c:1434 UCX  ERROR failed to open CM on component rdmacm with status Input/output error
+[1667967651.726943] [relqc01:3882148:0]      rdmacm_cm.c:638  UCX  ERROR rdma_create_event_channel failed: No such device
+[1667967651.726952] [relqc01:3882148:0]     ucp_worker.c:1434 UCX  ERROR failed to open CM on component rdmacm with status Input/output error
+[1667967651.726940] [relqc01:3882149:0]      rdmacm_cm.c:638  UCX  ERROR rdma_create_event_channel failed: No such device
+[1667967651.726948] [relqc01:3882149:0]     ucp_worker.c:1434 UCX  ERROR failed to open CM on component rdmacm with status Input/output error
+  ** interface to 64-bit integer MPI enabled **
+
+DIRAC master    (relqc01) starts by allocating       64000000 r*8 words (   0.477 GB) of memory
+DIRAC nodes 1 to 3 starts by allocating            64000000 r*8 words (   0.477 GB) of memory
+DIRAC master    (relqc01) to allocate at most      2147483648 r*8 words (  16.000 GB) of memory
+DIRAC nodes 1 to 3 to allocate at most           2147483648 r*8 words (  16.000 GB) of memory
+ 
+Note: maximum allocatable memory for master+nodes can be set by -aw (MW)/-ag (GB) flags in pam
+ 
+ *******************************************************************************
+ *                                                                             *
+ *                                O U T P U T                                  *
+ *                                   from                                      *
+ *                                                                             *
+ *                   @@@@@    @@   @@@@@     @@@@     @@@@@                    *
+ *                   @@  @@        @@  @@   @@  @@   @@                        *
+ *                   @@  @@   @@   @@@@@    @@@@@@   @@                        *
+ *                   @@  @@   @@   @@ @@    @@  @@   @@                        *
+ *                   @@@@@    @@   @@  @@   @@  @@    @@@@@                    *
+ *                                                                             *
+ *                                                                             *
+ %}ZS)S?$=$)]S?$%%>SS$%S$ZZ6cHHMHHHHHHHHMHHM&MHbHH6$L/:<S///</:|/:|:/::!:.::--:%
+ $?S$$%$$$$?%?$(SSS$SSSHMMMMMMMMMMMMMMMMMM6H&6S&SH&&k?6$r~::://///::::::.:::-::$
+ (%?)Z??$$$(S%$>$)S6HMMMMMMMMMMMMMMMMMMMMMMR6M]&&$6HR$&6(i::::::|i|:::::::-:-::(
+ $S?$$)$?$%?))?S/]#MMMMMMMMMMMMMMMMMMMMMMMMMMHM1HRH9R&$$$|):?:/://|:/::/:/.::.:$
+ SS$%%?$%((S)?Z[6MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM&HF$$&/)S?<~::!!:::::::/:-:|.S
+ SS%%%%S$%%%$$MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHHHHHHM>?/S/:/:::`:/://:/::-::S
+ ?$SSSS?%SS$)MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM/4?:S:/:::/:::/:/:::.::?
+ S$(S?S$%(?$HMMMMMMMMMMMMMMMMM#&7RH99MMMMMMMMMMMMMMMMMMHHHd$/:::::/::::::-//.:.S
+ (?SS(%)S&HMMMMMMMMMMMMMMMMM#S|///???$9HHMMMMMMMMMDSZ&1S/?</>?~:///::|/!:/-:-:.(
+ $S?%?<H(MMMMMMMMMMMMMMMMR?`. :.:`::<>:``?/*?##*)$:/>       `((%://::/:::::/::/$
+ S$($$)HdMMMMMMMMMMMMMMMP: . `   `  `    `      `-            `Z<:>?::/:::::|:iS
+ c%%%&HMMMMMMMMMMMMMMMM6:                                      `$%)>%%</>!:::::c
+ S?%/MMMMMMMMMMMMMMMMMMH-                                        /ZSS>?:?~:;/::S
+ $SZ?MMMMMMMMMMMMMMMMMH?.                                        \"&((/?//?|:::$
+ $%$%&MMMMMMMMMMMMMMMMM:.                                          ?%/S:</::/::$
+ ($?}&HMMMMMMMMMMMMMMMM>:                                          $%%<?/i:|i::(
+ Z$($&MMMMMMMMMMMMMMMMHk(:.  . -                                   .S/\?\?/!:/:Z
+ (??$<HMMMMMMMMMMMMMMMFk|:   -.-.                                  :%/%/(:/:ii|(
+ SZ(S?]MMMMMMMMMMMMMMHS?:- -  ::.:                                  |/S:</::?||S
+ $%)$$(MMMMMMMMMMMMMMR):`:. :.:::`,,/bcokb/_                       :S?%?|~:/:/:$
+ %$$%$)[[?$?MMMMMMMMMM: :.:-.::::$7?<&7&MMMMMMM#/           _ .. ..:</?:(:/::::%
+ $$$?Z?HHH~|/MMMMMMMMM/`.-.:.:/:%%%%?dHMMMMMMMMMMH?,-   .,bMMMM6//./i~/~:<:::/:$
+ $($S$M//::S?ZHMMMMMH/:.`:::.:/%S/&MMHMMMMMMMMRM&><   ,HMMMMMMMF  :::?:///:|:::$
+ )[$S$S($|_i:#>::*H&?/::.::/:\"://:?>>`:&HMHSMMMM$:`-   MMHMMMMHHT .)i/?////::/)
+ $$[$$>$}:dHH&$$--?S::-:.:::--/-:``./::>%Zi?)&/?`:.`   `H?$T*\" `  /%?>%:)://ii$
+ $&=&/ZS}$RF<:?/-.|%r/:::/:/:`.-.-..|::S//!`\"``          >??:    `SS<S:)!/////$
+ Z&]>b[Z(Z?&%:::../S$$:>:::i`.`. `-.`  `                         ,>%%%:>/>/!|:/Z
+ $$&/F&1$c$?>:>?/,>?$$ZS/::/:-: ...                              |S?S)S?<~:::::$
+ &$&$&$k&>>|?<:<?((/$[/?)i~/:/. - -                              S?:%%%?/:::/::&
+ =[/Z[[Fp[MMH$>?Z&S$$$/$S///||..-           -.-                  /((S$:%<:///:/=
+ $&>1MHHMMMM6M9MMMM$Z$}$S%/:::.`.            .:/,,,dcb>/:.       ((SSSS%:)!//i|$
+ MMMMMMMMMMMR&&RRRHR&&($(?:|i::-             .:%&S&$[&H&``     ../>%;/?>??:<::>M
+ MMMMMMMMMMMMS/}S$&&H&[$SS//:::.:.   . . .v</Jq1&&D]&M&<,      :/::/?%%)S>?://:M
+ MMMMMMMMMMMM?}$/$$kMM&&$(%/?//:..`.  .|//1d/`://?*/*/\"` `     .:/(SS$%(S%)):%M
+ MMMMMMMMMMMM(}$$>&&MMHR#$S%%:?::.:|-.`:;&&b/D/$p=qpv//b/~`   :/~~%%??$=$)Z$S+;M
+ MMMMMMMMMMMM[|S$$Z1]MMMMD[$?$:>)/::: :/?:``???bD&{b<<-`     .,:/)|SS(}Z/$$?/<SM
+ MMMMMMMMMMMM||$)&7k&MMMMH9]$$??Z%|!/:i::`  `` .             SS?SS?Z/]1$/&$c/$SM
+ MMMMMMMMMMMM| -?>[&]HMMMMMMMH1[/7SS(?:/..-` ::/Sc,/_,     _<$?SS%$S/&c&&$&>//<M
+ MMMMMMMMMMMMR  `$&&&HMM9MMMMMMM&&c$%%:/:/:.:.:/\?\?/\    _MMHk/7S/]dq&1S<&&></M
+ MMMMMMMMMMMMM?  :&96MHMMMMMMMMMMMHHk[S%(<<:// `         ,MMMMMMM&/Z6H]DkH]1$&&M
+ MMMMMMMMMMMMMD    99H9HMMMMMMMMMMMMMMMb&%$<:i.:....    .MMMMMMMMM6HHHRH&H&H1SFM
+ MMMMMMMMMMMMMM|   `?HMMMMMMMMMMMMMMMMMMMHk6k&>$&Z$/?_.bHMMMMMMMMMMM&6HRM9H6]ZkM
+ MMMMMMMMMMMMMMM/    `TMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHMH6RH&R6&M
+ MMMMMMMMMMMMMMMM    -|?HMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMFHH6HMD&&M
+ MMMMMMMMMMMMMMMMk  ..:~?9MMMMMMMMMMMMM#`:MMMMMMMMMMMMMMMMMMMMMMMMMMMMM9MHkR6&FM
+ MMMMMMMMMMMMMMMMM/  .-!:%$ZHMMMMMMMMMR` dMMMMMMMMMMMMMMMMMMMMMMMMMMMMM9MRMHH9&M
+ MMMMMMMMMMMMMMMMMML,:.-|::/?&&MMMMMM` .MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHRMH&&6M
+ MMMMMMMMMMMMMMMMMMMc%>/:::i<:SMMMMMMHdMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHHM&969kM
+ MMMMMMMMMMMMMMMMMMMMSS/$$/(|HMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHH&HH&M
+ MMMMMMMMMMMMMMMMMMMM6S/?/MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMR96H1DR1M
+ MMMMMMMMMMMMMMMMMMMMM&$MHMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHMH691&&M
+ MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMH&R&9ZM
+ MMMMMMMMMMMMMMMMMMMMMMMMMRHMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMH&96][6M
+ MMMMMMMMMMMMMMMMMMMMMMMMp?:MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM96HH1][FM
+ MMMMMMMMMMMMMMMMMMMMMMMM> -HMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMH&1k&$&M
+ *******************************************************************************
+ *                                                                             *
+ *         =========================================================           *
+ *                     Program for Atomic and Molecular                        *
+ *          Direct Iterative Relativistic All-electron Calculations            *
+ *         =========================================================           *
+ *                                                                             *
+ *                                                                             *
+ *    Written by:                                                              *
+ *                                                                             *
+ *    Radovan Bast             UiT The Arctic University of      Norway        *
+ *    Andre S. P. Gomes        CNRS/Universite de Lille          France        *
+ *    Trond Saue               Universite Toulouse III           France        *
+ *    Lucas Visscher           Vrije Universiteit Amsterdam      Netherlands   *
+ *    Hans Joergen Aa. Jensen  University of Southern Denmark    Denmark       *
+ *                                                                             *
+ *    with contributions from:                                                 *
+ *                                                                             *
+ *    Ignacio Agustin Aucar    CONICET/Northeastern University   Argentina     *
+ *    Vebjoern Bakken          University of Oslo                Norway        *
+ *    Kenneth G. Dyall         Schrodinger, Inc., Portland       USA           *
+ *    Sebastien Dubillard      University of Strasbourg          France        *
+ *    Ulf Ekstroem             University of Oslo                Norway        *
+ *    Ephraim Eliav            University of Tel Aviv            Israel        *
+ *    Thomas Enevoldsen        University of Southern Denmark    Denmark       *
+ *    Elke Fasshauer           University of Aarhus              Denmark       *
+ *    Timo Fleig               Universite Toulouse III           France        *
+ *    Olav Fossgaard           UiT The Arctic University of      Norway        *
+ *    Loic Halbert             Universite de Lille               France        *
+ *    Erik D. Hedegaard        University of Southern Denmark    Denmark       *
+ *    Trygve Helgaker          University of Oslo                Norway        *
+ *    Benjamin Helmich-Paris   Max Planck Institute f. Coal Res. Germany       *
+ *    Johan Henriksson         Linkoeping University             Sweden        *
+ *    Miroslav Ilias           Matej Bel University              Slovakia      *
+ *    Christoph R. Jacob       TU Braunschweig                   Germany       *
+ *    Stefan Knecht            GSI Darmstadt/JGU Mainz           Germany       *
+ *    Stanislav Komorovsky     Slovak Academy of Sciences        Slovakia      *
+ *    Ossama Kullie            University of Kassel              Germany       *
+ *    Jon K. Laerdahl          University of Oslo                Norway        *
+ *    Christoffer V. Larsen    University of Southern Denmark    Denmark       *
+ *    Yoon Sup Lee             KAIST, Daejeon                    South Korea   *
+ *    Nanna Holmgaard List     Stanford University               USA           *
+ *    Huliyar S. Nataraj       BME/Budapest Univ. Tech. & Econ.  Hungary       *
+ *    Malaya Kumar Nayak       Bhabha Atomic Research Centre     India         *
+ *    Patrick Norman           Stockholm Inst. of Technology     Sweden        *
+ *    Malgorzata Olejniczak    University of Warsaw              Poland        *
+ *    Jeppe Olsen              Aarhus University                 Denmark       *
+ *    Jogvan Magnus H. Olsen   University of Southern Denmark    Denmark       *
+ *    Anastasios Papadopoulos  Max Planck Institute f. Coal Res. Germany       *
+ *    Young Choon Park         KAIST, Daejeon                    South Korea   *
+ *    Jesper K. Pedersen       University of Southern Denmark    Denmark       *
+ *    Markus Pernpointner      University of Heidelberg          Germany       *
+ *    Johann V. Pototschnig    Technical University Graz         Austria       *
+ *    Roberto Di Remigio       UiT The Arctic University of      Norway        *
+ *    Michal Repisky           UiT The Arctic University of      Norway        *
+ *    Kenneth Ruud             UiT The Arctic University of      Norway        *
+ *    Pawel Salek              Stockholm Inst. of Technology     Sweden        *
+ *    Bernd Schimmelpfennig    Karlsruhe Institute of Technology Germany       *
+ *    Bruno Senjean            University of Leiden              Netherlands   *
+ *    Avijit Shee              University of Michigan            USA           *
+ *    Jetze Sikkema            Vrije Universiteit Amsterdam      Netherlands   *
+ *    Ayaki Sunaga             Kyoto University                  Japan         *
+ *    Andreas J. Thorvaldsen   UiT The Arctic University of      Norway        *
+ *    Joern Thyssen            University of Southern Denmark    Denmark       *
+ *    Joost N. P. van Stralen  Vrije Universiteit Amsterdam      Netherlands   *
+ *    Marta L. Vidal           Technical University of Denmark   Denmark       *
+ *    Sebastien Villaume       Linkoeping University             Sweden        *
+ *    Olivier Visser           University of Groningen           Netherlands   *
+ *    Toke Winther             University of Southern Denmark    Denmark       *
+ *    Shigeyoshi Yamamoto      Chukyo University                 Japan         *
+ *                                                                             *
+ *    For more information about the DIRAC code see http://diracprogram.org    *
+ *                                                                             *
+ *    This is an experimental code. The authors accept no responsibility       *
+ *    for the performance of the code or for the correctness of the results.   *
+ *                                                                             *
+ *    The code (in whole or part) is not to be reproduced for further          *
+ *    distribution without the written permission of the authors or            *
+ *    their representatives.                                                   *
+ *                                                                             *
+ *    If results obtained with this code are published, an                     *
+ *    appropriate citation would be:                                           *
+ *                                                                             *
+ *    DIRAC, a relativistic ab initio electronic structure program,            *
+ *    Release DIRAC21 (2021), written by                                       *
+ *    T. Saue, L. Visscher, H. J. Aa. Jensen, R. Bast, and A. S. P. Gomes      *
+ *    with contributions from I. A. Aucar, V. Bakken, K. G. Dyall,             *
+ *    S. Dubillard, U. Ekstroem, E. Eliav, T. Enevoldsen, E. Fasshauer,        *
+ *    T. Fleig, O. Fossgaard, L. Halbert, E. D. Hedegaard, T. Helgaker,        *
+ *    J. Henriksson, M. Ilias, Ch. R. Jacob, S. Knecht, S. Komorovsky,         *
+ *    O. Kullie, J. K. Laerdahl, C. V. Larsen, Y. S. Lee, N. H. List,          *
+ *    H. S. Nataraj, M. K. Nayak, P. Norman, M. Olejniczak, J. Olsen,          *
+ *    J. M. H. Olsen, A. Papadopoulos, Y. C. Park, J. K. Pedersen,             *
+ *    M. Pernpointner, J. V. Pototschnig, R. Di Remigio, M. Repisky, K. Ruud,  *
+ *    P. Salek, B. Schimmelpfennig, B. Senjean, A. Shee, J. Sikkema, A. Sunaga,*
+ *    A. J. Thorvaldsen, J. Thyssen, J. N. P. van Stralen, M. L. Vidal,        *
+ *    S. Villaume, O. Visser, T. Winther, and S. Yamamoto,                     *
+ *    (see http://diracprogram.org).                                           *
+ *                                                                             *
+ *    as well as our reference paper: J. Chem. Phys. 152 (2020) 204104.        *
+ *                                                                             *
+ *******************************************************************************
+
+
+Version information
+-------------------
+
+Branch        | 
+Commit hash   | 
+Commit author | 
+Commit date   | 
+
+
+Configuration and build information
+-----------------------------------
+
+Who compiled             | noda
+Compiled on server       | relqc01
+Operating system         | Linux-3.10.0-957.27.2.el7.x86_64
+CMake version            | 3.21.3
+CMake generator          | Unix Makefiles
+CMake build type         | release
+Configuration time       | 2021-11-08 16:17:02.823538
+Python version           | 
+Fortran compiler         | /home/noda/Software/DIRAC/21.1/openmpi310_i8/bin/mpif90
+Fortran compiler version | 19.0
+Fortran compiler flags   |  -xHost -I/home/noda/Software/DIRAC/21.1/openmpi310_i8/lib -w -assume byterecl -g -traceback -DVAR_IFORT  -qopenmp -i8
+C compiler               | /home/noda/Software/DIRAC/21.1/openmpi310_i8/bin/mpicc
+C compiler version       | 19.0
+C compiler flags         |  -xHost -g -wd981 -wd279 -wd383 -wd1572 -wd177  -qopenmp
+C++ compiler             | /home/noda/Software/DIRAC/21.1/openmpi310_i8/bin/mpicxx
+C++ compiler version     | 19.0.5
+C++ compiler flags       |  -xHost -Wno-unknown-pragmas  -qopenmp
+Static linking           | False
+64-bit integers          | True
+MPI parallelization      | True
+MPI launcher             | /home/noda/Software/DIRAC/21.1/openmpi310_i8/bin/mpiexec
+Math libraries           | unknown
+Builtin BLAS library     | OFF
+Builtin LAPACK library   | OFF
+Explicit libraries       | unknown
+Compile definitions      | HAVE_MKL_BLAS;HAVE_MKL_LAPACK;HAVE_MPI;HAVE_OPENMP;VAR_MPI;VAR_MPI2;USE_MPI_MOD_F90;SYS_LINUX;PRG_DIRAC;INT_STAR8;INSTALL_WRKMEM=64000000;HAS_PCMSOLVER;BUILD_GEN1INT;HAS_PELIB;MOD_QCORR;HAS_STIELTJES
+
+EXACORR dependencies
+--------------------
+Exatensor source repo    | unknown
+Exatensor git hash       | unknown
+Exatensor configuration  | unknown
+
+
+ LAPACK integer*4/8 selftest passed
+ Selftest of ISO_C_BINDING Fortran - C/C++ interoperability PASSED
+ MPI selftest passed with MPI_INTEGER of the size 8 bytes
+
+
+ * openMP activated,  thread limit - # processes - # threads: *****   48    1
+
+Execution time and host
+-----------------------
+
+ 
+     Date and time (Linux)  : Wed Nov  9 13:20:51 2022
+     Host name              : relqc01                                 
+
+
+Contents of the input file
+--------------------------
+
+**DIRAC                                                                                             
+.TITLE                                                                                              
+Ar                                                                                                  
+.WAVE FUNCTION                                                                                      
+.ANALYZE                                                                                            
+.PROPERTIES                                                                                         
+**INTEGRALS                                                                                         
+.NUCMOD                                                                                             
+1                                                                                                   
+*READIN                                                                                             
+.UNCONTRACT                                                                                         
+**HAMILTONIAN                                                                                       
+.X2C                                                                                                
+**WAVE FUNCTIONS                                                                                    
+.SCF                                                                                                
+.RELCCSD                                                                                            
+*SCF                                                                                                
+.MAXITR                                                                                             
+ 100                                                                                                
+.EVCCNV                                                                                             
+ 1.0E-10                                                                                            
+.ERGCNV                                                                                             
+ 1.0E-10                                                                                            
+**ANALYZE                                                                                           
+.MULPOP                                                                                             
+.PRIVEC                                                                                             
+*PRIVEC                                                                                             
+.VECPRI                                                                                             
+all                                                                                                 
+all                                                                                                 
+**PROPERTIES                                                                                        
+.RHONUC                                                                                             
+**GENERAL                                                                                           
+.PCMOUT                                                                                             
+**MOLTRA                                                                                            
+.ACTIVE                                                                                             
+all                                                                                                 
+**MOLECULE                                                                                          
+*BASIS                                                                                              
+.DEFAULT                                                                                            
+ dyall.3zp                                                                                          
+*END OF                                                                                             
+
+
+Contents of the molecule file
+-----------------------------
+
+1                                                                                                   
+                                                                                                    
+Ar      0.0000000000        0.0000000000        0.0000000000                                        
+                                                                                                    
+                                                                                                    
+
+
+    **************************************************************************
+    *********************************** Ar ***********************************
+    **************************************************************************
+
+ Jobs in this run:
+   * Wave function
+   * Analysis
+   * Properties
+
+
+    **************************************************************************
+    ************************** General DIRAC set-up **************************
+    **************************************************************************
+
+ The 2018 CODATA Recommended Values of the Fundamental Physical Constants (Web V
+ ersion 8.1)
+        Eite Tiesinga, Peter J. Mohr, David B. Newell, and Barry N. Taylor      
+            
+        Database developed by J. Baker, M. Douma, and S. Kotochigova            
+            
+  Available at http://physics.nist.gov/constants                                
+            
+  National Institute of Standards and Technology, Gaithersburg, MD 20899        
+            
+ * The speed of light :        137.0359992
+ * Running in two-component mode
+ * Parallel run with 3 slaves.
+ * Direct evaluation of the following two-electron integrals:
+   - LL-integrals
+ * Spherical transformation embedded in MO-transformation
+   for large components
+ * Transformation to scalar RKB basis embedded in
+   MO-transformation for small components
+ * Thresholds for linear dependence:
+   Large components:   1.00D-06
+   Small components:   1.00D-08
+ * MO-coefficients written to formatted file DFPCMO
+ * General print level   :   0
+
+
+    *************************************************************************
+    ****************** Output from HERMIT input processing ******************
+    *************************************************************************
+
+ Default print level:        1
+ Nuclear model requested in input: Point charge.
+
+ Two-electron integrals not calculated.
+
+
+ Ordinary (field-free non-relativistic) Hamiltonian integrals not calculated.
+
+
+
+ Changes of defaults for *READIN
+ -------------------------------
+
+
+ Uncontracted basis forced, irrespective of basis input file.
+
+
+
+   ***************************************************************************
+   ****************** Output from MOLECULE input processing ******************
+   ***************************************************************************
+
+
+
+                     SYMADD: Detection of molecular symmetry
+                     ---------------------------------------
+
+ Symmetry test threshold:  5.00E-06
+
+ Symmetry point group found: D(oo,h)        
+
+ The following symmetry elements were found: X  Y  Z  
+
+
+  Symmetry Operations
+  -------------------
+
+  Symmetry operations: 3
+
+
+
+                          SYMGRP:Point group information
+                          ------------------------------
+
+Full group is:  D(oo,h)        
+Represented as: D2h
+
+   * The point group was generated by:
+
+      Reflection in the yz-plane
+      Reflection in the xz-plane
+      Reflection in the xy-plane
+
+   * Group multiplication table
+
+        |  E   C2z  C2y  C2x   i   Oxy  Oxz  Oyz
+   -----+----------------------------------------
+     E  |  E   C2z  C2y  C2x   i   Oxy  Oxz  Oyz
+    C2z | C2z   E   C2x  C2y  Oxy   i   Oyz  Oxz
+    C2y | C2y  C2x   E   C2z  Oxz  Oyz   i   Oxy
+    C2x | C2x  C2y  C2z   E   Oyz  Oxz  Oxy   i 
+     i  |  i   Oxy  Oxz  Oyz   E   C2z  C2y  C2x
+    Oxy | Oxy   i   Oyz  Oxz  C2z   E   C2x  C2y
+    Oxz | Oxz  Oyz   i   Oxy  C2y  C2x   E   C2z
+    Oyz | Oyz  Oxz  Oxy   i   C2x  C2y  C2z   E 
+
+   * Character table
+
+        |  E   C2z  C2y  C2x   i   Oxy  Oxz  Oyz
+   -----+----------------------------------------
+    Ag  |   1    1    1    1    1    1    1    1
+    B3u |   1   -1   -1    1   -1    1    1   -1
+    B2u |   1   -1    1   -1   -1    1   -1    1
+    B1g |   1    1   -1   -1    1    1   -1   -1
+    B1u |   1    1   -1   -1   -1   -1    1    1
+    B2g |   1   -1    1   -1    1   -1    1   -1
+    B3g |   1   -1   -1    1    1   -1   -1    1
+    Au  |   1    1    1    1   -1   -1   -1   -1
+
+   * Direct product table
+
+        | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au 
+   -----+----------------------------------------
+    Ag  | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au 
+    B3u | B3u  Ag   B1g  B2u  B2g  B1u  Au   B3g
+    B2u | B2u  B1g  Ag   B3u  B3g  Au   B1u  B2g
+    B1g | B1g  B2u  B3u  Ag   Au   B3g  B2g  B1u
+    B1u | B1u  B2g  B3g  Au   Ag   B3u  B2u  B1g
+    B2g | B2g  B1u  Au   B3g  B3u  Ag   B1g  B2u
+    B3g | B3g  Au   B1u  B2g  B2u  B1g  Ag   B3u
+    Au  | Au   B3g  B2g  B1u  B1g  B2u  B3u  Ag 
+
+
+                            **************************
+                            *** Output from DBLGRP ***
+                            **************************
+
+   * Two fermion irreps:  E1g  E1u
+   * Real group. NZ = 1
+   * Direct product decomposition:
+          E1g x E1g : Ag  + B1g + B2g + B3g
+          E1u x E1g : Au  + B1u + B2u + B3u
+          E1u x E1u : Ag  + B1g + B2g + B3g
+
+
+                                 Spinor structure
+                                 ----------------
+
+
+   * Fermion irrep no.: 1            * Fermion irrep no.: 2
+
+      La  |  Ag (1)  B1g(2)  |                La  |  Au (1)  B1u(2)  |
+      Sa  |  Au (1)  B1u(2)  |                Sa  |  Ag (1)  B1g(2)  |
+      Lb  |  B2g(3)  B3g(4)  |                Lb  |  B2u(3)  B3u(4)  |
+      Sb  |  B2u(3)  B3u(4)  |                Sb  |  B2g(3)  B3g(4)  |
+
+
+                              Quaternion symmetries
+                              ---------------------
+
+    Rep  T(+)
+    -----------------------------
+    Ag   1
+    B3u  k
+    B2u  j
+    B1g  i
+    B1u  i
+    B2g  j
+    B3g  k
+    Au   1
+
+  QM-QM nuclear repulsion energy :      0.000000000000
+
+
+
+  Atoms and basis sets
+  --------------------
+
+  Number of atom types :    1
+  Total number of atoms:    1
+
+  label    atoms   charge   prim    cont     basis   
+  ----------------------------------------------------------------------
+  Ar          1      18      69      69      L  - [18s11p3d|18s11p3d]                                            
+  ----------------------------------------------------------------------
+                             69      69      L  - large components
+  ----------------------------------------------------------------------
+  total:      1      18      69      69
+
+  Cartesian basis used.
+  Threshold for integrals (to be written to file):  1.00D-15
+
+
+  References for the basis sets
+  -----------------------------
+
+  Atom type   1
+   1s-3s: K.G. Dyall, Theor. Chem. Acc. (2016) 135:128.                           
+   4s-7s: K.G. Dyall, J. Phys. Chem. A. (2009) 113:12638.                         
+   2p-3p: K.G. Dyall, Theor. Chem. Acc. (2016) 135:128.                           
+   4p-6p: K.G. Dyall, Theor. Chem. Acc. (2002) 108:335;                           
+          revision K.G. Dyall, Theor. Chem. Acc. (2006) 115:441.                  
+      7p: K.G. Dyall, Theor. Chem. Acc. (2012) 131:1172.                          
+      3d: K.G. Dyall and A.S.P. Gomes, unpublished.                               
+      4d: K.G. Dyall, Theor. Chem. Acc. (2007) 117:483.                           
+      5d: K.G. Dyall, Theor. Chem. Acc. (2004) 112:403;                           
+          revision  K.G. Dyall and A.S.P. Gomes, Theor. Chem. Acc. (2009) 125:97. 
+
+
+  Cartesian Coordinates (bohr)
+  ----------------------------
+
+  Total number of coordinates:  3
+
+
+   1   Ar       x      0.0000000000
+   2            y      0.0000000000
+   3            z      0.0000000000
+
+
+
+  Cartesian coordinates in XYZ format (Angstrom)
+  ----------------------------------------------
+
+    1
+ 
+Ar     0.0000000000   0.0000000000   0.0000000000
+
+
+  Symmetry Coordinates
+  --------------------
+
+  Number of coordinates in each symmetry:     0    1    1    0    1    0    0    0
+
+
+  Symmetry  B3u( 2)
+
+    1   Ar    x    1
+
+
+  Symmetry  B2u( 3)
+
+    2   Ar    y    2
+
+
+  Symmetry  B1u( 5)
+
+    3   Ar    z    3
+
+
+  This is an atomic calculation.
+
+                       * Total mass:    39.962383 amu
+                       * Natural abundance:  99.600 %
+
+
+* Center-of-mass coordinates (a.u.):       0.000000000000000   0.000000000000000   0.000000000000000
+* Center-of-mass coordinates (A)   :       0.000000000000000   0.000000000000000   0.000000000000000
+
+
+                                GETLAB: AO-labels
+                                -----------------
+
+   * Large components:   10
+     1  L Ar  1 s        2  L Ar  1 px       3  L Ar  1 py       4  L Ar  1 pz       5  L Ar  1 dxx      6  L Ar  1 dxy 
+     7  L Ar  1 dxz      8  L Ar  1 dyy      9  L Ar  1 dyz     10  L Ar  1 dzz 
+   * Small components:    0
+
+
+
+                                GETLAB: SO-labels
+                                -----------------
+
+   * Large components:   10
+     1  L Ag Ar s        2  L Ag Ar dxx      3  L Ag Ar dyy      4  L Ag Ar dzz      5  L B3uAr px       6  L B2uAr py  
+     7  L B1gAr dxy      8  L B1uAr pz       9  L B2gAr dxz     10  L B3gAr dyz 
+   * Small components:    0
+
+
+
+  Symmetry Orbitals
+  -----------------
+
+  Number of orbitals in each symmetry:           27    11    11     3    11     3     3     0
+  Number of large orbitals in each symmetry:     27    11    11     3    11     3     3     0
+  Number of small orbitals in each symmetry:      0     0     0     0     0     0     0     0
+
+* Large component functions
+
+  Symmetry  Ag ( 1)
+
+       18 functions:    Ar s   
+        3 functions:    Ar dxx 
+        3 functions:    Ar dyy 
+        3 functions:    Ar dzz 
+
+  Symmetry  B3u( 2)
+
+       11 functions:    Ar px  
+
+  Symmetry  B2u( 3)
+
+       11 functions:    Ar py  
+
+  Symmetry  B1g( 4)
+
+        3 functions:    Ar dxy 
+
+  Symmetry  B1u( 5)
+
+       11 functions:    Ar pz  
+
+  Symmetry  B2g( 6)
+
+        3 functions:    Ar dxz 
+
+  Symmetry  B3g( 7)
+
+        3 functions:    Ar dyz 
+
+
+   ***************************************************************************
+   *************************** Hamiltonian defined ***************************
+   ***************************************************************************
+
+
+ One-electron operator origins:
+ - General operator origin (a.u.)       :   0.000000000000000   0.000000000000000   0.000000000000000
+ - Magnetic gauge origin (a.u.)         :   0.000000000000000   0.000000000000000   0.000000000000000
+ - Dipole (and multipole) origin (a.u.) :   0.000000000000000   0.000000000000000   0.000000000000000
+  - BSS with properties !
+ * Print level:    0
+ * Exact-Two-Component (X2C) Hamiltonian
+   Reference: 
+    M. Ilias and T. Saue:
+    "Implementation of an infinite-order two-component relativistic Hamiltonian 
+    by a simple one-step transformation." 
+    J. Chem. Phys., 126 (2007) 064102.
+   additional reference for the new X2C module:
+    S. Knecht and T. Saue:
+    manuscript in preparation, Strasbourg 2010.
+
+ * Running in two-component mode
+ * Default integral flags passed to all modules
+   - LL-integrals:     1
+   - LS-integrals:     0
+   - SS-integrals:     0
+   - GT-integrals:     0
+===========================================================================
+   Set-up for AMFI/RELSCF calculations
+===========================================================================
+  ...no reading under "*AMFI  ", thus default settings
+ * AMFI   code print level:    0
+ * RELSCF code print level:    0
+ * RELSCF maximum number of iterations:   50
+ * All AMFI mean-field summations are on neutral individual atoms.
+ * order of AMFI contributions to the X2C Hamiltonian:  2
+  --> adding spin-same orbit MFSSO2 terms.
+
+
+    **************************************************************************
+    ************************** Wave function module **************************
+    **************************************************************************
+
+ Wave function types requested (in input order):
+     HF        
+     RELCCSD   
+
+ Wave function jobs in execution order (expanded):
+ * Hartree-Fock calculation
+ * Run RELCCSD code
+
+ * Initial Automatic occupation based on:
+   Total charge of atoms =  18
+   Charge of molecule    =   0
+   i.e. no. of electrons =  18
+===========================================================================
+ *SCF: Set-up for Hartree-Fock calculation:
+===========================================================================
+ * Number of fermion irreps: 2
+ * Sum of atomic potentials used for start guess
+ * General print level   :   0
+
+ ***** INITIAL TRIAL SCF FUNCTION *****
+ * Trial vectors read from file DFCOEF
+ * Scaling of active-active block correction to open shell Fock operator    0.500000
+   to improve convergence (default value).
+
+ ***** SCF CONVERGENCE CRITERIA *****
+ * Convergence on total energy.
+   Desired convergence:1.000D-10
+   Allowed convergence:1.000D-10
+
+ ***** CONVERGENCE CONTROL *****
+ * Fock matrix constructed using differential density matrix
+    with optimal parameter.
+ * DIIS (in MO basis)
+ * DIIS will be activated when convergence reaches : 1.00D+20
+   - Maximum size of B-matrix:   10
+ * Damping of Fock matrix when DIIS is not activated. 
+   Weight of old matrix    : 0.250
+ * Maximum number of SCF iterations  :  100
+ * No quadratic convergent Hartree-Fock
+ * DHF occupation is allowed to change during SCF cycles.
+ * Contributions from 2-electron integrals to Fock matrix:
+   LL-integrals.
+    ---> this is default setting from Hamiltonian input
+ * NB!!! No e-p rotations in 2nd order optimization.
+ ***** OUTPUT CONTROL *****
+ * Only electron eigenvalues written out.
+===========================================================================
+ **RELCC: Set-up for Coupled Cluster calculations
+===========================================================================
+
+
+   ***************************************************************************
+   ***************************** Analysis module *****************************
+   ***************************************************************************
+
+ Jobs in this run:
+ * Write vectors
+ * Mulliken population analysis
+===========================================================================
+ VECINP: Vector print
+===========================================================================
+ * Coefficients written in SO-basis
+ * Vector print:
+    - Orbitals in fermion ircop E1g :all                                                                     
+    - Orbitals in fermion ircop E1u :all                                                                     
+ * Only large component coefficients written out.
+===========================================================================
+ POPINP: Mulliken population analysis
+===========================================================================
+ * Gross populations
+ * Label definitions based on SO-labels
+ * Number of spinors analyzed:
+    - All occupied orbitals in fermion ircop E1g
+    - All occupied orbitals in fermion ircop E1u
+ * Print level:    0
+
+
+   ***************************************************************************
+   ***************************** Property module *****************************
+   ***************************************************************************
+
+ * Print level:   0
+ * Input label: **PROPE
+ * Properties calculated for the following wave functions:
+     1: DHF 
+ These initial settings of center and origins might be changed later:
+ * Operator center (a.u.):      0.0000000000      0.0000000000      0.0000000000
+ * Gauge origin    (a.u.):      0.0000000000      0.0000000000      0.0000000000
+ * Dipole origin   (a.u.):      0.0000000000      0.0000000000      0.0000000000
+ * Perform 4c->2c picture change transformation of the four-component property operators
+===========================================================================
+ Electronic density at nuclei
+===========================================================================
+===========================================================================
+ TRPINP: Property integral transformation
+===========================================================================
+ * Print level:    0
+ *The following operators will be transformed:
+    1  XDIPLEN              B3u     T+
+...........................................................................
+      Operator type DIAGONAL : scalar operator
+      Labels and factors     : XDIPLEN  +00+     1.0000000000000 (real)     
+...........................................................................
+    2  YDIPLEN              B2u     T+
+...........................................................................
+      Operator type DIAGONAL : scalar operator
+      Labels and factors     : YDIPLEN  +00+     1.0000000000000 (real)     
+...........................................................................
+    3  ZDIPLEN              B1u     T+
+...........................................................................
+      Operator type DIAGONAL : scalar operator
+      Labels and factors     : ZDIPLEN  +00+     1.0000000000000 (real)     
+...........................................................................
+---------------------------------------------------------------------------
+
+
+
+===========================================================================
+ TRAINP: Set-up for index transformation
+===========================================================================
+
+ * General print level   :   0
+ * Electronic orbitals only.
+ * Total active space.
+    Fermion ircop:E1g
+    all                                                                     
+    Fermion ircop:E1u
+    all                                                                     
+
+ * Set-up for 2-index transformation
+ * LS Integrals not included in core Fock-matrix
+ * SS Integrals not included in core Fock-matrix
+ * Active spaces:
+    Fermion ircop:E1g
+    - Index  1:  all                                                                     
+    - Index  2:  all                                                                     
+    Fermion ircop:E1u
+    - Index  1:  all                                                                     
+    - Index  2:  all                                                                     
+
+ * Set-up for 4-index transformation
+ * Following scheme      :   6
+ - write half-transformed integrals (ij|rs) to disk
+ - sorting of intermediate 1HT integrals is disabled
+ * Screening threshold :1.00E-14
+ * MO integral threshold :1.00E-14
+ * LS Integrals not transformed.
+ * SS Integrals not transformed.
+ * Gaunt Integrals not transformed.
+ * Active spaces:
+    Fermion ircop:E1g
+    - Index  1:  all                                                                     
+    - Index  2:  all                                                                     
+    - Index  3:  all                                                                     
+    - Index  4:  all                                                                     
+    Fermion ircop:E1u
+    - Index  1:  all                                                                     
+    - Index  2:  all                                                                     
+    - Index  3:  all                                                                     
+    - Index  4:  all                                                                     
+
+
+ ********************************************************************************
+ *************************** Input consistency checks ***************************
+ ********************************************************************************
+
+
+
+    *************************************************************************
+    ************************ End of input processing ************************
+    *************************************************************************
+
+
+
+   ***************************************************************************
+   ****************** Output from MOLECULE input processing ******************
+   ***************************************************************************
+
+
+
+                     SYMADD: Detection of molecular symmetry
+                     ---------------------------------------
+
+ Symmetry test threshold:  5.00E-06
+
+ Symmetry point group found: D(oo,h)        
+
+ The following symmetry elements were found: X  Y  Z  
+
+
+  Symmetry Operations
+  -------------------
+
+  Symmetry operations: 3
+
+
+
+                          SYMGRP:Point group information
+                          ------------------------------
+
+Full group is:  D(oo,h)        
+Represented as: D2h
+
+   * The point group was generated by:
+
+      Reflection in the yz-plane
+      Reflection in the xz-plane
+      Reflection in the xy-plane
+
+   * Group multiplication table
+
+        |  E   C2z  C2y  C2x   i   Oxy  Oxz  Oyz
+   -----+----------------------------------------
+     E  |  E   C2z  C2y  C2x   i   Oxy  Oxz  Oyz
+    C2z | C2z   E   C2x  C2y  Oxy   i   Oyz  Oxz
+    C2y | C2y  C2x   E   C2z  Oxz  Oyz   i   Oxy
+    C2x | C2x  C2y  C2z   E   Oyz  Oxz  Oxy   i 
+     i  |  i   Oxy  Oxz  Oyz   E   C2z  C2y  C2x
+    Oxy | Oxy   i   Oyz  Oxz  C2z   E   C2x  C2y
+    Oxz | Oxz  Oyz   i   Oxy  C2y  C2x   E   C2z
+    Oyz | Oyz  Oxz  Oxy   i   C2x  C2y  C2z   E 
+
+   * Character table
+
+        |  E   C2z  C2y  C2x   i   Oxy  Oxz  Oyz
+   -----+----------------------------------------
+    Ag  |   1    1    1    1    1    1    1    1
+    B3u |   1   -1   -1    1   -1    1    1   -1
+    B2u |   1   -1    1   -1   -1    1   -1    1
+    B1g |   1    1   -1   -1    1    1   -1   -1
+    B1u |   1    1   -1   -1   -1   -1    1    1
+    B2g |   1   -1    1   -1    1   -1    1   -1
+    B3g |   1   -1   -1    1    1   -1   -1    1
+    Au  |   1    1    1    1   -1   -1   -1   -1
+
+   * Direct product table
+
+        | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au 
+   -----+----------------------------------------
+    Ag  | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au 
+    B3u | B3u  Ag   B1g  B2u  B2g  B1u  Au   B3g
+    B2u | B2u  B1g  Ag   B3u  B3g  Au   B1u  B2g
+    B1g | B1g  B2u  B3u  Ag   Au   B3g  B2g  B1u
+    B1u | B1u  B2g  B3g  Au   Ag   B3u  B2u  B1g
+    B2g | B2g  B1u  Au   B3g  B3u  Ag   B1g  B2u
+    B3g | B3g  Au   B1u  B2g  B2u  B1g  Ag   B3u
+    Au  | Au   B3g  B2g  B1u  B1g  B2u  B3u  Ag 
+
+
+                            **************************
+                            *** Output from DBLGRP ***
+                            **************************
+
+   * Two fermion irreps:  E1g  E1u
+   * Real group. NZ = 1
+   * Direct product decomposition:
+          E1g x E1g : Ag  + B1g + B2g + B3g
+          E1u x E1g : Au  + B1u + B2u + B3u
+          E1u x E1u : Ag  + B1g + B2g + B3g
+
+
+                                 Spinor structure
+                                 ----------------
+
+
+   * Fermion irrep no.: 1            * Fermion irrep no.: 2
+
+      La  |  Ag (1)  B1g(2)  |                La  |  Au (1)  B1u(2)  |
+      Sa  |  Au (1)  B1u(2)  |                Sa  |  Ag (1)  B1g(2)  |
+      Lb  |  B2g(3)  B3g(4)  |                Lb  |  B2u(3)  B3u(4)  |
+      Sb  |  B2u(3)  B3u(4)  |                Sb  |  B2g(3)  B3g(4)  |
+
+
+                              Quaternion symmetries
+                              ---------------------
+
+    Rep  T(+)
+    -----------------------------
+    Ag   1
+    B3u  k
+    B2u  j
+    B1g  i
+    B1u  i
+    B2g  j
+    B3g  k
+    Au   1
+
+  QM-QM nuclear repulsion energy :      0.000000000000
+
+
+
+  Atoms and basis sets
+  --------------------
+
+  Number of atom types :    1
+  Total number of atoms:    1
+
+  label    atoms   charge   prim    cont     basis   
+  ----------------------------------------------------------------------
+  Ar          1      18      69      69      L  - [18s11p3d|18s11p3d]                                            
+  ----------------------------------------------------------------------
+                             69      69      L  - large components
+                            170     170      S  - small components
+  ----------------------------------------------------------------------
+  total:      1      18     239     239
+
+  Cartesian basis used.
+  Threshold for integrals (to be written to file):  1.00D-15
+
+
+  References for the basis sets
+  -----------------------------
+
+  Atom type   1
+   1s-3s: K.G. Dyall, Theor. Chem. Acc. (2016) 135:128.                           
+   4s-7s: K.G. Dyall, J. Phys. Chem. A. (2009) 113:12638.                         
+   2p-3p: K.G. Dyall, Theor. Chem. Acc. (2016) 135:128.                           
+   4p-6p: K.G. Dyall, Theor. Chem. Acc. (2002) 108:335;                           
+          revision K.G. Dyall, Theor. Chem. Acc. (2006) 115:441.                  
+      7p: K.G. Dyall, Theor. Chem. Acc. (2012) 131:1172.                          
+      3d: K.G. Dyall and A.S.P. Gomes, unpublished.                               
+      4d: K.G. Dyall, Theor. Chem. Acc. (2007) 117:483.                           
+      5d: K.G. Dyall, Theor. Chem. Acc. (2004) 112:403;                           
+          revision  K.G. Dyall and A.S.P. Gomes, Theor. Chem. Acc. (2009) 125:97. 
+
+
+  Cartesian Coordinates (bohr)
+  ----------------------------
+
+  Total number of coordinates:  3
+
+
+   1   Ar       x      0.0000000000
+   2            y      0.0000000000
+   3            z      0.0000000000
+
+
+
+  Cartesian coordinates in XYZ format (Angstrom)
+  ----------------------------------------------
+
+    1
+ 
+Ar     0.0000000000   0.0000000000   0.0000000000
+
+
+  Symmetry Coordinates
+  --------------------
+
+  Number of coordinates in each symmetry:     0    1    1    0    1    0    0    0
+
+
+  Symmetry  B3u( 2)
+
+    1   Ar    x    1
+
+
+  Symmetry  B2u( 3)
+
+    2   Ar    y    2
+
+
+  Symmetry  B1u( 5)
+
+    3   Ar    z    3
+
+
+  This is an atomic calculation.
+
+                       * Total mass:    39.962383 amu
+                       * Natural abundance:  99.600 %
+
+
+* Center-of-mass coordinates (a.u.):       0.000000000000000   0.000000000000000   0.000000000000000
+* Center-of-mass coordinates (A)   :       0.000000000000000   0.000000000000000   0.000000000000000
+
+
+                      Nuclear contribution to dipole moments
+                      --------------------------------------
+
+                    All dipole components are zero by symmetry
+
+Total time used in ONEGEN (CPU)  0.02059300s and (WALL)  0.05756783s
+
+
+                       Generating Lowdin canonical matrix:
+                       -----------------------------------
+
+   L   Ag    * Deleted:          3(Proj:          3, Lindep:          0) Smin: 0.82E-03
+   L   B1g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.16E+00
+   L   B2g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.16E+00
+   L   B3g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.16E+00
+   S   B3u   * Deleted:          3(Proj:          3, Lindep:          0) Smin: 0.48E-04
+   S   B2u   * Deleted:          3(Proj:          3, Lindep:          0) Smin: 0.48E-04
+   S   B1u   * Deleted:          3(Proj:          3, Lindep:          0) Smin: 0.48E-04
+   S   Au    * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.23E+00
+   L   B3u   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.72E-02
+   L   B2u   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.72E-02
+   L   B1u   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.72E-02
+   S   Ag    * Deleted:         11(Proj:         11, Lindep:          0) Smin: 0.75E-02
+   S   B1g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.20E-01
+   S   B2g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.20E-01
+   S   B3g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.20E-01
+
+                   *********************************************************************
+                   ***   Entering the Exact-Two-Component (X2C) interface in DIRAC   ***
+                   ***                                                               ***
+                   *** library version:  1.2 (August  2013)                          ***
+                   ***                                                               ***
+                   *** authors:          - Stefan Knecht                             ***
+                   ***                   - Trond Saue                                ***
+                   *** contributors:     - Hans Joergen Aagaard Jensen               ***
+                   ***                   - Michal Repisky                            ***
+                   ***                   - Miroslav Ilias                            ***
+                   *** features:         - X2C                                       ***
+                   ***                   - X2C-atomic/fragment (X2C-LU)              ***
+                   ***                   - X2C-spinfree                              ***
+                   ***                   - X2C-molecular-mean-field (X2Cmmf)         ***
+                   ***                                                               ***
+                   ***                      Universities of                          ***
+                   ***     Zuerich, Toulouse, Odense, Banska Bystrica and Tromsoe    ***
+                   ***                                                               ***
+                   *** contact: stefan.knecht@phys.chem.ethz.ch                      ***
+                   *********************************************************************
+
+
+                   *** chosen path in X2C module: molecular X2C (with spin-orbit contributions)      
+
+
+                                Output from MODHAM
+                                ------------------
+
+ * Applied strict kinetic balance !
+ * Applied SL-regrouping on AO2MO tranf.matrix in SLSORT.
+
+
+                                Output from AMFIIN
+                                ------------------
+
+
+  *** number of unique nuclei (from file MNF.INP): 1
+
+  *** calculate AMFI for atom type 1 with atomic charge    18
+  *** number of nuclei with identical atom type:   1
+   unique nuclei index: 1
+  *** file with AMFI integrals for this center: AOPROPER_MNF.18.1   
+
+
+                         ATOMIC NO-PAIR SO-MF CODE starts
+                         --------------------------------
+
+   Douglas-Kroll type operators 
+  charge on the calculated atom:  0
+  Mean-field summation for electrons #:  18
+    ...electronic occupation of Ar: [Ne]3s^2 3p^6             
+ ****  Written to the file TOSCF for "relscf" ****
+        charge: 18.000
+      nprimit:  18 11  3  0
+   closed sh.:   3  2  0  0
+     open sh.:   0  0  0  0
+
+
+                       *** PROGRAM AT34 - ALLIANT - @V ***
+                       -----------------------------------
+
+
+      SYMMETRY SPECIES            S       P       D       F
+      NUMBER OF BASIS FUNCTIONS: 18      11       3
+      NUMBER OF CLOSED SHELLS  :  3       2       0
+      OPEN SHELL OCCUPATION    :  0       0       0
+  ### SCF ITERATIONS           ###
+  ### NON-RELATIVISTIC APPROX. ###
+    1. iteration,  total energy:             0.000000000000
+    2. iteration,  total energy:          -294.061436642679
+    3. iteration,  total energy:          -490.064657058964
+    4. iteration,  total energy:          -514.832327554098
+    5. iteration,  total energy:          -525.141827991024
+    6. iteration,  total energy:          -526.687610942331
+    7. iteration,  total energy:          -526.805300071676
+    8. iteration,  total energy:          -526.815893205146
+    9. iteration,  total energy:          -526.816816429117
+   10. iteration,  total energy:          -526.816938520996
+   11. iteration,  total energy:          -526.816948468475
+   12. iteration,  total energy:          -526.816949654137
+   13. iteration,  total energy:          -526.816949771238
+   14. iteration,  total energy:          -526.816949698244
+   15. iteration,  total energy:          -526.816949706294
+   16. iteration,  total energy:          -526.816949704384
+   16. iteration,  total energy:          -526.816949705030
+  ### NON-RELATIVISTIC APPROX. ###
+        16      -0.5268169497D+03      -0.1053637204D+04       0.5268202548D+03      -0.1999993726D+01
+  ### SCF ITERATIONS           ###
+  ### EV APPROX.               ###
+    1. iteration,  total energy:          -528.340998933932
+    2. iteration,  total energy:          -528.627113582196
+    3. iteration,  total energy:          -528.627305340866
+    4. iteration,  total energy:          -528.627318174235
+    5. iteration,  total energy:          -528.627319326335
+    6. iteration,  total energy:          -528.627319405379
+    7. iteration,  total energy:          -528.627319418067
+    8. iteration,  total energy:          -528.627319419236
+    9. iteration,  total energy:          -528.627319480677
+   10. iteration,  total energy:          -528.627319419353
+   11. iteration,  total energy:          -528.627319419355
+   11. iteration,  total energy:          -528.627319419354
+  ### EV  OPERATOR RESULT      ###
+        11      -0.5286273194D+03      -0.1061238063D+04       0.5326107436D+03      -0.1992520947D+01
+      *** AMFIIN: ADDING nucleus    1 with charge  18 to the BSSn Hamiltonian.
+
+                   *********************************************************************
+                   ***               X2C transformation ended properly.              ***
+                   ***          Calculation continues in two-component mode.         ***
+                   *********************************************************************
+
+ >>> CPU  time used in mk_h2c is   0.12 seconds
+ >>> WALL time used in mk_h2c is   0.13 seconds
+
+
+                     SYMADD: Detection of molecular symmetry
+                     ---------------------------------------
+
+ Symmetry test threshold:  5.00E-06
+
+ Symmetry point group found: D(oo,h)        
+
+ The following symmetry elements were found: X  Y  Z  
+
+
+                      Nuclear contribution to dipole moments
+                      --------------------------------------
+
+                    All dipole components are zero by symmetry
+
+Total time used in ONEGEN (CPU)  0.00458100s and (WALL)  0.00527096s
+
+
+                       Generating Lowdin canonical matrix:
+                       -----------------------------------
+
+   L   Ag    * Deleted:          3(Proj:          3, Lindep:          0) Smin: 0.82E-03
+   L   B1g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.16E+00
+   L   B2g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.16E+00
+   L   B3g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.16E+00
+   L   B3u   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.72E-02
+   L   B2u   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.72E-02
+   L   B1u   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.72E-02
+
+
+                                Output from ATMSYM
+                                ------------------
+
+
+ Parity  Kappa  MJ  Functions(total) Functions(LC) Functions(SC)
+     1   -1    1/2         18            18             0
+     1    2    1/2          3             3             0
+     1    2   -3/2          3             3             0
+     1   -3    1/2          3             3             0
+     1   -3   -3/2          3             3             0
+     1   -3    5/2          3             3             0
+    -1    1    1/2         11            11             0
+    -1   -2    1/2         11            11             0
+    -1   -2   -3/2         11            11             0
+
+
+      **********************************************************************
+      ************************* Orbital dimensions *************************
+      **********************************************************************
+
+                                   Irrep 1 Irrep 2   Sum
+No. of electronic orbitals (NESH):    33      33      66
+No. of positronic orbitals (NPSH):     0       0       0
+Total no. of orbitals      (NORB):    33      33      66
+ >>> CPU  time used in PAMSET is   0.16 seconds
+ >>> WALL time used in PAMSET is   0.21 seconds
+
+
+ *******************************************************************************
+ *********************** X2C relativistic HF calculation ***********************
+ *******************************************************************************
+
+
+*** INFO *** No trial vectors found.
+ Using sum of fitted atomic potentials as start potential.
+
+ Reference: S. Lehtola, L. Visscher, E. Engel,  J. Chem. Phys. 152 (2020) 144105. (small GRASP fit)
+
+
+########## START ITERATION NO.   1 ##########   Wed Nov  9 13:20:52 2022
+
+
+* AUTOCC( 0) : Initial occupation:
+
+ * Closed shell SCF calculation with    18 electrons in
+       3 orbitals in Fermion irrep 1 and    6 orbitals in Fermion irrep 2
+E_HOMO...E_LUMO, symmetry 1:                                  3  -0.82475    4   0.28754
+E_HOMO...E_LUMO, symmetry 2:                                 39  -0.31464   40   0.28982
+
+=> Calculating sum of orbital energies
+It.    1    -303.8656445785      0.00D+00  0.00D+00  0.00D+00               0.00778900s   Atom. scrpot   Wed Nov  9
+
+########## START ITERATION NO.   2 ##########   Wed Nov  9 13:20:52 2022
+
+
+* GETGAB: label "GABAO1XX" not found; calling GABGEN.
+SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
+SOfock:LL  1.00D-12    5.30%    3.68%    2.28%   25.96%   0.22864699s
+ >>> CPU  time used in SO Fock is   0.24 seconds
+ >>> WALL time used in SO Fock is   0.24 seconds
+E_HOMO...E_LUMO, symmetry 1:                                  3  -1.31080    4   0.42250
+E_HOMO...E_LUMO, symmetry 2:                                 39  -0.60866   40   0.39631
+>>> Total wall time:  0.25056505s, and total CPU time :  0.24499100s
+
+########## END ITERATION NO.   2 ##########   Wed Nov  9 13:20:52 2022
+
+It.    2    -528.6107508278      2.25D+02  1.14D+01  1.64D+00               0.25056505s   LL             Wed Nov  9
+
+########## START ITERATION NO.   3 ##########   Wed Nov  9 13:20:52 2022
+
+    3 *** Differential density matrix. DCOVLP     = 1.0150
+SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
+SOfock:LL  1.00D-12    5.30%    6.95%    1.95%   25.34%   0.01625586s
+E_HOMO...E_LUMO, symmetry 1:                                  3  -1.28156    4   0.43496
+E_HOMO...E_LUMO, symmetry 2:                                 39  -0.58359   40   0.40317
+>>> Total wall time:  0.02417612s, and total CPU time :  0.02059200s
+
+########## END ITERATION NO.   3 ##########   Wed Nov  9 13:20:52 2022
+
+It.    3    -528.6329250637      2.22D-02  1.52D-01  9.59D-02   DIIS   2    0.02417612s   LL             Wed Nov  9
+
+########## START ITERATION NO.   4 ##########   Wed Nov  9 13:20:52 2022
+
+    4 *** Differential density matrix. DCOVLP     = 1.0003
+SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
+SOfock:LL  1.00D-12    5.30%    9.00%    1.72%   25.04%   0.01799393s
+E_HOMO...E_LUMO, symmetry 1:                                  3  -1.28715    4   0.43359
+E_HOMO...E_LUMO, symmetry 2:                                 39  -0.58838   40   0.40224
+>>> Total wall time:  0.02539897s, and total CPU time :  0.02193700s
+
+########## END ITERATION NO.   4 ##########   Wed Nov  9 13:20:52 2022
+
+It.    4    -528.6332934940      3.68D-04 -4.03D-02  2.18D-02   DIIS   3    0.02539897s   LL             Wed Nov  9
+
+########## START ITERATION NO.   5 ##########   Wed Nov  9 13:20:52 2022
+
+    5 *** Differential density matrix. DCOVLP     = 1.0005
+SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
+SOfock:LL  1.00D-12    5.30%   12.39%    1.58%   24.50%   0.01915288s
+E_HOMO...E_LUMO, symmetry 1:                                  3  -1.28622    4   0.43403
+E_HOMO...E_LUMO, symmetry 2:                                 39  -0.58764   40   0.40246
+>>> Total wall time:  0.02646184s, and total CPU time :  0.02305800s
+
+########## END ITERATION NO.   5 ##########   Wed Nov  9 13:20:52 2022
+
+It.    5    -528.6333206454      2.72D-05  1.15D-02  1.94D-03   DIIS   4    0.02646184s   LL             Wed Nov  9
+
+########## START ITERATION NO.   6 ##########   Wed Nov  9 13:20:52 2022
+
+    6 *** Differential density matrix. DCOVLP     = 1.0000
+SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
+SOfock:LL  1.00D-12    5.30%   15.01%    1.45%   24.03%   0.01840401s
+E_HOMO...E_LUMO, symmetry 1:                                  3  -1.28618    4   0.43407
+E_HOMO...E_LUMO, symmetry 2:                                 39  -0.58763   40   0.40247
+>>> Total wall time:  0.02569699s, and total CPU time :  0.02239500s
+
+########## END ITERATION NO.   6 ##########   Wed Nov  9 13:20:52 2022
+
+It.    6    -528.6333210361      3.91D-07 -7.15D-04  1.30D-04   DIIS   5    0.02569699s   LL             Wed Nov  9
+
+########## START ITERATION NO.   7 ##########   Wed Nov  9 13:20:52 2022
+
+    7 *** Differential density matrix. DCOVLP     = 1.0000
+SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
+SOfock:LL  1.00D-12    5.30%   21.67%    1.27%   22.88%   0.01919198s
+E_HOMO...E_LUMO, symmetry 1:                                  3  -1.28617    4   0.43407
+E_HOMO...E_LUMO, symmetry 2:                                 39  -0.58762   40   0.40247
+>>> Total wall time:  0.02640104s, and total CPU time :  0.02303800s
+
+########## END ITERATION NO.   7 ##########   Wed Nov  9 13:20:52 2022
+
+It.    7    -528.6333210417      5.61D-09  2.58D-05  1.52D-05   DIIS   6    0.02640104s   LL             Wed Nov  9
+
+########## START ITERATION NO.   8 ##########   Wed Nov  9 13:20:52 2022
+
+    8 *** Differential density matrix. DCOVLP     = 1.0000
+SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
+SOfock:LL  1.00D-12    5.30%   27.67%    1.06%   21.70%   0.01846814s
+>>> Total wall time:  0.02306318s, and total CPU time :  0.01976000s
+
+########## END ITERATION NO.   8 ##########   Wed Nov  9 13:20:52 2022
+
+It.    8    -528.6333210417      4.38D-11 -7.23D-06  2.03D-06   DIIS   6    0.02306318s   LL             Wed Nov  9
+
+
+                                   SCF - CYCLE
+                                   -----------
+
+* Convergence on total energy.
+  Desired convergence :1.000D-10
+  Allowed convergence:1.000D-10
+
+* ERGVAL - convergence in total energy
+* FCKVAL - convergence in maximum change in total Fock matrix
+* EVCVAL - convergence in error vector (gradient)
+--------------------------------------------------------------------------------------------------------------------------------
+           Energy               ERGVAL    FCKVAL    EVCVAL      Conv.acc    CPU          Integrals   Time stamp
+--------------------------------------------------------------------------------------------------------------------------------
+It.    1    -303.8656445785      0.00D+00  0.00D+00  0.00D+00               0.00778900s   Atom. scrpot   Wed Nov  9
+It.    2    -528.6107508278      2.25D+02  1.14D+01  1.64D+00               0.25056505s   LL             Wed Nov  9
+It.    3    -528.6329250637      2.22D-02  1.52D-01  9.59D-02   DIIS   2    0.02417612s   LL             Wed Nov  9
+It.    4    -528.6332934940      3.68D-04 -4.03D-02  2.18D-02   DIIS   3    0.02539897s   LL             Wed Nov  9
+It.    5    -528.6333206454      2.72D-05  1.15D-02  1.94D-03   DIIS   4    0.02646184s   LL             Wed Nov  9
+It.    6    -528.6333210361      3.91D-07 -7.15D-04  1.30D-04   DIIS   5    0.02569699s   LL             Wed Nov  9
+It.    7    -528.6333210417      5.61D-09  2.58D-05  1.52D-05   DIIS   6    0.02640104s   LL             Wed Nov  9
+It.    8    -528.6333210417      4.38D-11 -7.23D-06  2.03D-06   DIIS   6    0.02306318s   LL             Wed Nov  9
+--------------------------------------------------------------------------------------------------------------------------------
+* Convergence after    8 iterations.
+* Average elapsed time per iteration: 
+      No 2-ints    :    0.00823784s
+      LL           :    0.05739474s
+
+
+                                   TOTAL ENERGY
+                                   ------------
+
+   Electronic energy                        :    -528.63332104171104
+
+   Other contributions to the total energy
+   Nuclear repulsion energy                 :       0.00000000000000
+
+   Sum of all contributions to the energy
+   Total energy                             :    -528.63332104171104
+
+
+                                   Eigenvalues
+                                   -----------
+
+
+* Block   1 in E1g:  s 1/2;  1/2
+  * Closed shell, f = 1.0000
+   -119.0897651561  ( 2)       -12.4087156329  ( 2)        -1.2861708365  ( 2)
+  * Virtual eigenvalues, f = 0.0000
+      0.4340708135  ( 2)         2.4845431715  ( 2)         9.7193638313  ( 2)        32.4889375321  ( 2)        98.6409265597  ( 2)
+    275.5419326282  ( 2)       716.7782668951  ( 2)      1786.8943844757  ( 2)      4325.8096214988  ( 2)     10112.5162752038  ( 2)
+  22614.2098913938  ( 2)     48809.0210807704  ( 2)    105277.6718878655  ( 2)    240809.0895349689  ( 2)    655381.8607855224  ( 2)
+
+* Block   2 in E1g:  d 3/2;  1/2
+  * Virtual eigenvalues, f = 0.0000
+      0.6799253018  ( 2)         2.4709748123  ( 2)         7.3660741088  ( 2)
+
+* Block   3 in E1g:  d 3/2; -3/2
+  * Virtual eigenvalues, f = 0.0000
+      0.6799253018  ( 2)         2.4709748123  ( 2)         7.3660741088  ( 2)
+
+* Block   4 in E1g:  d 5/2;  1/2
+  * Virtual eigenvalues, f = 0.0000
+      0.6800780647  ( 2)         2.4717998157  ( 2)         7.3680616158  ( 2)
+
+* Block   5 in E1g:  d 5/2; -3/2
+  * Virtual eigenvalues, f = 0.0000
+      0.6800780647  ( 2)         2.4717998157  ( 2)         7.3680616158  ( 2)
+
+* Block   6 in E1g:  d 5/2;  5/2
+  * Virtual eigenvalues, f = 0.0000
+      0.6800780647  ( 2)         2.4717998157  ( 2)         7.3680616158  ( 2)
+
+* Block   1 in E1u:  p 1/2;  1/2
+  * Closed shell, f = 1.0000
+     -9.6307690618  ( 2)        -0.5951735376  ( 2)
+  * Virtual eigenvalues, f = 0.0000
+      0.4024736817  ( 2)         1.9203990692  ( 2)         6.6641839792  ( 2)        20.4290596990  ( 2)        58.2348504395  ( 2)
+    162.5725395861  ( 2)       469.2447243178  ( 2)      1482.8918624539  ( 2)      5631.7219253246  ( 2)
+
+* Block   2 in E1u:  p 3/2;  1/2
+  * Closed shell, f = 1.0000
+     -9.5459312906  ( 2)        -0.5876208935  ( 2)
+  * Virtual eigenvalues, f = 0.0000
+      0.4046413928  ( 2)         1.9294572396  ( 2)         6.6923943844  ( 2)        20.5089579358  ( 2)        58.4624541274  ( 2)
+    163.3059472943  ( 2)       472.1897692940  ( 2)      1497.5953295574  ( 2)      5757.7286886750  ( 2)
+
+* Block   3 in E1u:  p 3/2; -3/2
+  * Closed shell, f = 1.0000
+     -9.5459312906  ( 2)        -0.5876208935  ( 2)
+  * Virtual eigenvalues, f = 0.0000
+      0.4046413928  ( 2)         1.9294572396  ( 2)         6.6923943844  ( 2)        20.5089579358  ( 2)        58.4624541274  ( 2)
+    163.3059472943  ( 2)       472.1897692940  ( 2)      1497.5953295574  ( 2)      5757.7286886750  ( 2)
+
+* Occupation in fermion symmetry E1g
+  * Inactive orbitals
+    s 1/2 s 1/2 s 1/2
+  Mj  1/2   1/2   1/2
+  * Virtual orbitals
+    s 1/2 d 3/2 d 3/2 d 5/2 d 5/2 d 5/2 d 3/2 d 3/2 d 5/2 d 5/2 d 5/2 s 1/2 d 3/2 d 3/2 d 5/2 d 5/2 d 5/2 s 1/2
+  Mj  1/2   1/2  -3/2  -3/2   5/2   1/2   1/2  -3/2   1/2   5/2  -3/2   1/2  -3/2   1/2  -3/2   5/2   1/2   1/2
+    s 1/2 s 1/2 s 1/2 s 1/2 s 1/2 s 1/2 s 1/2 s 1/2 s 1/2 s 1/2 s 1/2 s 1/2
+  Mj  1/2   1/2   1/2   1/2   1/2   1/2   1/2   1/2   1/2   1/2   1/2   1/2
+
+* Occupation in fermion symmetry E1u
+  * Inactive orbitals
+    p 1/2 p 3/2 p 3/2 p 1/2 p 3/2 p 3/2
+  Mj  1/2  -3/2   1/2   1/2   1/2  -3/2
+  * Virtual orbitals
+    p 1/2 p 3/2 p 3/2 p 1/2 p 3/2 p 3/2 p 1/2 p 3/2 p 3/2 p 1/2 p 3/2 p 3/2 p 1/2 p 3/2 p 3/2 p 1/2 p 3/2 p 3/2
+  Mj  1/2   1/2  -3/2   1/2  -3/2   1/2   1/2  -3/2   1/2   1/2  -3/2   1/2   1/2  -3/2   1/2   1/2   1/2  -3/2
+    p 1/2 p 3/2 p 3/2 p 1/2 p 3/2 p 3/2 p 1/2 p 3/2 p 3/2
+  Mj  1/2   1/2  -3/2   1/2  -3/2   1/2   1/2   1/2  -3/2
+
+* Occupation of subblocks
+                       E1g:  s 1/2 d 3/2 d 3/2 d 5/2 d 5/2 d 5/2                                                            
+                        Mj:    1/2   1/2  -3/2   1/2  -3/2   5/2                                                            
+  closed shells (f=1.0000):     3     0     0     0     0     0
+ virtual shells (f=0.0000):    15     3     3     3     3     3
+tot.num. of pos.erg shells:    18     3     3     3     3     3
+                       E1u:  p 1/2 p 3/2 p 3/2                                                                              
+                        Mj:    1/2   1/2  -3/2                                                                              
+  closed shells (f=1.0000):     2     2     2
+ virtual shells (f=0.0000):     9     9     9
+tot.num. of pos.erg shells:    11    11    11
+
+
+* HOMO - LUMO gap:
+
+    E(LUMO) :     0.40247368 au (symmetry E1u)
+  - E(HOMO) :    -0.58762089 au (symmetry E1u)
+  ------------------------------------------
+    gap     :     0.99009458 au
+
+
+
+    **************************************************************************
+    ****************************** Vector print ******************************
+    **************************************************************************
+
+
+
+   Coefficients from DFCOEF
+   ------------------------
+
+
+
+                                Fermion ircop E1g
+                                -----------------
+
+
+* Electronic eigenvalue no.  1: -119.08976515605
+====================================================
+       1  L Ag Ar s      -0.0000283289  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s      -0.0001030356  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -0.0003336255  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.0010304640  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.0031205613  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s      -0.0092347702  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.0262336507  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s      -0.0691145286  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.1590598940  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s      -0.2918058990  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.3565343843  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s      -0.2104017236  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -0.0305613285  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.0023545788  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.0014458886  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.0005528600  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.0002301060  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0000701951  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+
+* Electronic eigenvalue no.  2: -12.408715632851
+====================================================
+       1  L Ag Ar s      -0.0000081141  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s      -0.0000295169  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -0.0000956668  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.0002956001  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.0008984685  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s      -0.0026679185  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.0076952211  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s      -0.0207955732  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.0512436626  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s      -0.1069871012  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.1746319298  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s      -0.1393834805  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s       0.1901949902  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.5718352393  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s       0.3743666504  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.0336194007  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.0033494975  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0012838873  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  3: -1.2861708364985
+====================================================
+       1  L Ag Ar s      -0.0000025371  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s      -0.0000092273  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -0.0000299272  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.0000923587  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.0002814422  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s      -0.0008332089  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.0024178867  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s      -0.0065119037  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.0162777930  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s      -0.0340958861  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.0582386738  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s      -0.0470617504  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s       0.0701678256  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.3020492430  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s       0.3154009425  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s      -0.3337799316  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.6657719144  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s      -0.2502111543  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+
+* Electronic eigenvalue no.  4:  0.4340708135190
+====================================================
+       1  L Ag Ar s       0.0000013459  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0000048139  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0000163147  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       0.0000458719  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s       0.0001631239  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.0003797649  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s       0.0015070787  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.0026594388  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s       0.0110760084  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.0110335110  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s       0.0488841417  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s      -0.0139078981  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s       0.0643083591  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s      -0.4093445761  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s       0.2401487501  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s      -0.8149588508  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s       2.8355041323  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s      -2.3798957750  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+
+* Electronic eigenvalue no.  5:  0.6799253017508
+====================================================
+       1  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.0246964301  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0246964301  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0493928602  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx     0.0169239919  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.0169239919  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz    -0.0338479838  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.1633277806  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.1633277806  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.3266555613  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000 -0.0740892903  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0507719757  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000 -0.4899833419  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0740892903
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0507719757
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.4899833419
+
+* Electronic eigenvalue no.  6:  0.6799253017508
+====================================================
+       1  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx    -0.0427754717  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0427754717  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.0293132138  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.0293132138  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx    -0.2828920143  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.2828920143  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000  0.0855509434  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.0586264276  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000  0.5657840287  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0427754717  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000  0.0293132138  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.2828920143  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0427754717
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0293132138
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.2828920143
+
+* Electronic eigenvalue no.  7:  0.6800780647426
+====================================================
+       1  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.0213643702  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy    -0.0213643702  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx     0.0145922556  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.0145922556  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.1415034761  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy    -0.1415034761  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0427287404  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.0291845112  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.2830069522  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0854574809  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000  0.0583690224  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.5660139044  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0854574809
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0583690224
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.5660139044
+
+* Electronic eigenvalue no.  8:  0.6800780647430
+====================================================
+       1  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx    -0.0477721841  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0477721841  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.0326292755  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.0326292755  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx    -0.3164113916  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.3164113916  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0955443682  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.0652585509  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.6328227833  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+
+* Electronic eigenvalue no.  9:  0.6800780647431
+====================================================
+       1  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.0302137821  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0302137821  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0604275642  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx     0.0206365658  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.0206365658  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz    -0.0412731316  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.2001161350  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.2001161350  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.4002322701  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0604275642  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000  0.0412731316  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.4002322701  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0604275642
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0412731316
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.4002322701
+
+* Electronic eigenvalue no. 10:  2.4709748123452
+====================================================
+       1  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx    -0.0265925085  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy    -0.0265925085  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz     0.0531850169  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.1993560097  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.1993560097  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.3987120195  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.1591822500  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.1591822500  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.3183645000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0797775254  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000  0.5980680292  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000 -0.4775467499  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0797775254
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.5980680292
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.4775467499
+
+* Electronic eigenvalue no. 11:  2.4709748123452
+====================================================
+       1  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.0460595758  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy    -0.0460595758  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx     0.3452947376  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.3452947376  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx    -0.2757117446  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.2757117446  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0921191515  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.6905894753  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000  0.5514234893  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000 -0.0460595758  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.3452947376  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.2757117446  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0460595758
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.3452947376
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.2757117446
+
+* Electronic eigenvalue no. 12:  2.4717998156569
+====================================================
+       1  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.0325358182  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0325358182  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0650716364  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx     0.2442166970  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.2442166970  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz    -0.4884333939  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx    -0.1948836015  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy    -0.1948836015  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz     0.3897672029  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0650716364  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000  0.4884333939  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000 -0.3897672029  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0650716364
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.4884333939
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.3897672029
+
+* Electronic eigenvalue no. 13:  2.4717998156570
+====================================================
+       1  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx    -0.0514436455  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0514436455  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.3861405025  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.3861405025  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.3081380296  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy    -0.3081380296  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.1028872910  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.7722810051  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000  0.6162760592  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+
+* Electronic eigenvalue no. 14:  2.4717998156571
+====================================================
+       1  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.0230062977  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy    -0.0230062977  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx     0.1726872825  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.1726872825  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx    -0.1378035161  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.1378035161  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0460125953  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.3453745650  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000  0.2756070323  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0920251907  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000  0.6907491300  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000 -0.5512140645  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0920251907
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.6907491300
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.5512140645
+
+* Electronic eigenvalue no. 15:  2.4845431714609
+====================================================
+       1  L Ag Ar s       0.0000028347  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0000106156  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0000317753  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       0.0001150421  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s       0.0002619855  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.0011679980  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s       0.0018499396  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.0103223137  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s       0.0089782639  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.0655361104  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.0021379510  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       0.2055762239  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -0.4852411908  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.5667049168  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -2.3119322305  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       5.6511835619  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -5.4606958822  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       1.8635297517  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 16:  7.3660741087985
+====================================================
+       1  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx    -0.4918747031  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.4918747031  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx     0.4958688203  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.4958688203  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx    -0.1655866851  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.1655866851  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000  0.9837494062  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.9917376407  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000  0.3311733701  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.4918747031  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.4958688203  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.1655866851  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.4918747031
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.4958688203
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.1655866851
+
+* Electronic eigenvalue no. 17:  7.3660741087985
+====================================================
+       1  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.2839839922  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.2839839922  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.5679679845  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.2862899969  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.2862899969  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.5725799938  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.0956015172  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.0956015172  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.1912030344  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000 -0.8519519767  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000  0.8588699907  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000 -0.2868045516  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.8519519767
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.8588699907
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.2868045516
+
+* Electronic eigenvalue no. 18:  7.3680616158115
+====================================================
+       1  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.2459415809  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy    -0.2459415809  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.2479104079  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.2479104079  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.0827823002  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy    -0.0827823002  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.4918831618  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.4958208159  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.1655646005  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.9837663236  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.9916416318  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.3311292010  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.9837663236
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.9916416318
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.3311292010
+
+* Electronic eigenvalue no. 19:  7.3680616158123
+====================================================
+       1  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.5499420934  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy    -0.5499420934  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.5543445245  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.5543445245  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.1851068507  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy    -0.1851068507  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000  1.0998841868  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -1.1086890490  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000  0.3702137013  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+
+* Electronic eigenvalue no. 20:  7.3680616158125
+====================================================
+       1  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.3478139193  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.3478139193  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.6956278385  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.3505982612  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.3505982612  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.7011965223  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.1170718517  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.1170718517  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.2341437034  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.6956278385  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.7011965223  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.2341437034  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.6956278385
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.7011965223
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.2341437034
+
+* Electronic eigenvalue no. 21:  9.7193638313433
+====================================================
+       1  L Ag Ar s      -0.0000055752  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s      -0.0000190257  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -0.0000726236  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.0001540876  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.0008365276  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s      -0.0008489656  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.0088802449  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s      -0.0017047289  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.0750353761  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.0378550081  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.4270082559  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       0.5488166873  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -1.6847149405  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       6.0663012216  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -8.0222877247  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       6.1421278785  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -3.5174591906  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.9386360987  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 22:  32.488937532098
+====================================================
+       1  L Ag Ar s       0.0000094845  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0000386889  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0000888992  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       0.0005098742  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s       0.0003199286  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.0064419958  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.0029253737  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.0677870980  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.0701387286  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.5378062418  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.7908291106  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       2.7879779401  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -8.3350965702  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s      11.0629747199  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -7.4338857007  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       3.6090847247  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -1.8259903093  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.4765812435  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 23:  98.640926559717
+====================================================
+       1  L Ag Ar s      -0.0000174044  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s      -0.0000499664  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -0.0002789844  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.0001090708  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.0042905458  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.0048950453  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.0558123231  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.0938055205  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.5694771397  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       1.0913193508  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -4.6154487583  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       9.0953329933  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s     -10.3725348570  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       8.3885731651  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -4.4011644586  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       1.9344222866  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.9729430291  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.2562435872  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 24:  275.54193262820
+====================================================
+       1  L Ag Ar s       0.0000247837  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0001284679  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0000819908  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       0.0024184839  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.0039976931  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.0392690331  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.0889398523  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.4964758722  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -1.1809020022  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       5.4442885961  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s     -10.3214904803  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       9.8492049400  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -7.1235439575  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       4.9047734136  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -2.4533744962  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       1.0762755901  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.5457109704  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.1447419412  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 25:  716.77826689513
+====================================================
+       1  L Ag Ar s       0.0000506200  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0000796509  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0011799988  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.0022875227  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s       0.0245223156  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s      -0.0687140249  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s       0.3837900218  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s      -1.0963600058  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s       5.3579198176  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s      -9.7720755562  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s       9.7661763872  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s      -6.7012860798  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s       4.2099696183  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s      -2.8251057569  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s       1.4162257819  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s      -0.6272083002  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s       0.3198138435  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s      -0.0851334897  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+
+* Electronic eigenvalue no. 26:  1786.8943844757
+====================================================
+       1  L Ag Ar s       0.0000589523  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0005053821  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -0.0008994156  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       0.0138144591  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.0456859513  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.2743555335  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.9176786520  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       4.8020248666  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -8.3617638940  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       8.4098373590  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -6.4004731509  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       3.9935414143  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -2.4629039808  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       1.6622443364  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.8396865882  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.3744544319  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.1915213354  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0510728098  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 27:  4325.8096214988
+====================================================
+       1  L Ag Ar s      -0.0001900208  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0001271789  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -0.0069453517  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       0.0261915492  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.1832485552  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.7073721189  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -4.0836506965  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       6.7625809411  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -6.6584378487  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       5.2975199113  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -3.7636487347  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       2.3301097815  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -1.4498168092  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.9861106239  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.5007918446  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.2241920646  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.1148444620  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0306514051  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 28:  10112.516275204
+====================================================
+       1  L Ag Ar s       0.0001400877  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0030319306  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -0.0123536666  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       0.1138087746  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.5061047976  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       3.3711086856  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -5.2750673625  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       5.0011603358  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -4.0126918821  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       3.0392125917  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -2.1593412124  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       1.3494556991  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -0.8473087238  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.5791431358  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.2949690808  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.1323071803  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.0678255508  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0181093857  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 29:  22614.209891394
+====================================================
+       1  L Ag Ar s       0.0010983393  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s      -0.0040443421  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s       0.0645711252  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s      -0.3347616170  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s       2.7385278769  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s      -4.0016554156  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s       3.6031076728  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s      -2.8571844613  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s       2.2186359698  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s      -1.6903887929  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s       1.2134796235  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s      -0.7642323494  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s       0.4824230858  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s      -0.3305739037  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s       0.1686038379  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s      -0.0756947332  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s       0.0388168068  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s      -0.0103658645  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+
+* Electronic eigenvalue no. 30:  48809.021080770
+====================================================
+       1  L Ag Ar s      -0.0001147589  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.0320646960  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -0.2001299743  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       2.2075066216  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -2.9497745889  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       2.4862916183  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -1.9215660113  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       1.4967852524  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -1.1743336879  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.9043022506  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.6537163747  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       0.4134019876  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -0.2616293383  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.1794825086  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.0915982428  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.0411389107  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.0210992892  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0056348868  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 31:  105277.67188787
+====================================================
+       1  L Ag Ar s      -0.0124719902  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.1007669262  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -1.7767066815  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       2.0925058289  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -1.6207992306  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       1.2069845274  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.9291292589  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.7333847717  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.5812713978  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.4502964267  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.3265869460  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       0.2068976193  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -0.1310768943  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.0899620199  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.0459228139  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.0206280979  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.0105802985  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0028257109  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 32:  240809.08953497
+====================================================
+       1  L Ag Ar s      -0.0309977670  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       1.4379683316  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -1.3953369720  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       0.9659375148  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.6841412175  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.5137310115  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.4011434999  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.3194360139  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.2543648427  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.1975212835  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.1434314445  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       0.0909237138  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -0.0576244160  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.0395555204  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.0201935133  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.0090712024  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.0046527735  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0012426426  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 33:  655381.86078552
+====================================================
+       1  L Ag Ar s      -1.1880917457  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag Ar s       0.8115329717  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag Ar s      -0.4789258746  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag Ar s       0.3157865733  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag Ar s      -0.2275107535  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag Ar s       0.1730453724  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag Ar s      -0.1360202791  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag Ar s       0.1086554003  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag Ar s      -0.0866511179  0.0000000000  0.0000000000  0.0000000000
+      10  L Ag Ar s       0.0673356594  0.0000000000  0.0000000000  0.0000000000
+      11  L Ag Ar s      -0.0489137136  0.0000000000  0.0000000000  0.0000000000
+      12  L Ag Ar s       0.0310129030  0.0000000000  0.0000000000  0.0000000000
+      13  L Ag Ar s      -0.0196569735  0.0000000000  0.0000000000  0.0000000000
+      14  L Ag Ar s       0.0134938627  0.0000000000  0.0000000000  0.0000000000
+      15  L Ag Ar s      -0.0068889211  0.0000000000  0.0000000000  0.0000000000
+      16  L Ag Ar s       0.0030946445  0.0000000000  0.0000000000  0.0000000000
+      17  L Ag Ar s      -0.0015873051  0.0000000000  0.0000000000  0.0000000000
+      18  L Ag Ar s       0.0004239321  0.0000000000  0.0000000000  0.0000000000
+      19  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      20  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      21  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      22  L Ag Ar dxx    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      23  L Ag Ar dyy    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L Ag Ar dzz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L Ag Ar dxx     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L Ag Ar dyy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L Ag Ar dzz    -0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1gAr dxy     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1gAr dxy     0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B2gAr dxz     0.0000000000  0.0000000000 -0.0000000000  0.0000000000
+      33  L B2gAr dxz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      34  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
+      36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+
+                                Fermion ircop E1u
+                                -----------------
+
+
+* Electronic eigenvalue no.  1: -9.6307690617900
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0003194944
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0022228383
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0114598916
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0433789939
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1171039735
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.2103941389
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.2190777299
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0867582251
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0060419197
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0002459023
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0000216062
+      12  L B2uAr py      0.0000000000  0.0000000000  0.0003194944  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000  0.0022228383  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  0.0114598916  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000  0.0433789939  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  0.1171039735  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000  0.2103941389  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  0.2190777299  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  0.0867582251  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  0.0060419197  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  0.0002459023  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000 -0.0000216062  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.0003194944  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.0022228383  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -0.0114598916  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000 -0.0433789939  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -0.1171039735  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000 -0.2103941389  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -0.2190777299  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.0867582251  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -0.0060419197  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.0002459023  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000  0.0000216062  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  2: -9.5459312905742
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0002749549
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0024557580
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0134089635
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0519489910
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1417476017
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.2567687745
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.2697490290
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1083348161
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0077475864
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0002977565
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0000237494
+      12  L B2uAr py      0.0000000000  0.0000000000  0.0002749549  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000  0.0024557580  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  0.0134089635  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000  0.0519489910  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  0.1417476017  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000  0.2567687745  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  0.2697490290  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  0.1083348161  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  0.0077475864  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  0.0002977565  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000 -0.0000237494  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  3: -9.5459312905741
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0001587453
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0014178326
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0077416687
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0299927639
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0818380160
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1482455211
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1557396745
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0625471352
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0044730711
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0001719098
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0000137117
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0001587453  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.0014178326  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -0.0077416687  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -0.0299927639  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -0.0818380160  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.1482455211  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000 -0.1557396745  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -0.0625471352  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000 -0.0044730711  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -0.0001719098  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.0000137117  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.0003174905  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.0028356651  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -0.0154833373  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000 -0.0599855279  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -0.1636760320  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000 -0.2964910422  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -0.3114793490  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.1250942705  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -0.0089461422  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.0003438196  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000  0.0000274235  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  4: -0.5951735375871
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0000895759
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0006212560
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0032499799
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0124230796
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0349860387
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0642651198
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0745259976
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0247368294
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.2282785887
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.2905118591
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1267405592
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0000895759  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.0006212560  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -0.0032499799  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -0.0124230796  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -0.0349860387  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.0642651198  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000 -0.0745259976  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  0.0247368294  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  0.2282785887  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  0.2905118591  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.1267405592  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0000895759  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.0006212560  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  0.0032499799  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.0124230796  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000  0.0349860387  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  0.0642651198  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000  0.0745259976  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.0247368294  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -0.2282785887  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.2905118591  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.1267405592  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  5: -0.5876208934851
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0000445095
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0003957681
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0021934547
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0085797115
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0244178930
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0452308015
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0529808127
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0160958631
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1599374675
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.2057698965
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0917561228
+      12  L B2uAr py      0.0000000000  0.0000000000  0.0000445095  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000  0.0003957681  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  0.0021934547  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000  0.0085797115  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  0.0244178930  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000  0.0452308015  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  0.0529808127  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -0.0160958631  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000 -0.1599374675  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -0.2057698965  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000 -0.0917561228  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0000890189  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.0007915361  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  0.0043869094  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.0171594229  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000  0.0488357860  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  0.0904616030  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000  0.1059616253  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.0321917261  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -0.3198749351  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.4115397931  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.1835122456  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  6: -0.5876208934848
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0000770926
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0006854904
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0037991750
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0148604962
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0422930313
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0783420463
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0917654593
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0278788526
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.2770198198
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.3564039155
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1589262666
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0000770926  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.0006854904  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -0.0037991750  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -0.0148604962  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -0.0422930313  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.0783420463  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000 -0.0917654593  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  0.0278788526  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  0.2770198198  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  0.3564039155  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.1589262666  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  7:  0.4024736816918
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0000521769
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0002797342
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0019945384
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0053262094
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0229604682
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0205577920
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0759484283
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0985803828
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0529070842
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.6633927142
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.8643444712
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0000521769  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.0002797342  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -0.0019945384  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -0.0053262094  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -0.0229604682  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.0205577920  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000 -0.0759484283  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  0.0985803828  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000 -0.0529070842  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  0.6633927142  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000 -0.8643444712  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0000521769  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.0002797342  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  0.0019945384  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.0053262094  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000  0.0229604682  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  0.0205577920  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000  0.0759484283  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.0985803828  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000  0.0529070842  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.6633927142  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000  0.8643444712  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  8:  0.4046413928427
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0000272034
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0001768126
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0013678585
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0036994605
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0162127779
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0146169193
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0542810612
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0693218719
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0380974336
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.4725476163
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.6116286876
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0000272034  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.0001768126  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -0.0013678585  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -0.0036994605  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -0.0162127779  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.0146169193  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000 -0.0542810612  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  0.0693218719  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000 -0.0380974336  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  0.4725476163  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000 -0.6116286876  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.0000544068  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.0003536253  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -0.0027357171  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000 -0.0073989209  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -0.0324255557  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000 -0.0292338386  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -0.1085621225  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000  0.1386437438  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -0.0761948671  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000  0.9450952326  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -1.2232573751  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  9:  0.4046413928427
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0000471177
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0003062485
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0023692005
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0064076535
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0280813550
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0253172469
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0940175560
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1200690042
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0659866906
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.8184764804
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.0593719622
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0000471177  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.0003062485  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -0.0023692005  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -0.0064076535  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -0.0280813550  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.0253172469  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000 -0.0940175560  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  0.1200690042  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000 -0.0659866906  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  0.8184764804  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000 -1.0593719622  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 10:  1.9203990691688
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0000857522
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0009188414
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0027220776
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0195851854
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0240074511
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1321014067
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0579676487
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.2991211273
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.3321431374
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.4533627244
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.5509980467
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0000857522  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.0009188414  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -0.0027220776  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -0.0195851854  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -0.0240074511  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.1321014067  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  0.0579676487  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -0.2991211273  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  1.3321431374  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -1.4533627244  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.5509980467  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0000857522  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.0009188414  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  0.0027220776  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.0195851854  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000  0.0240074511  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  0.1321014067  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -0.0579676487  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000  0.2991211273  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -1.3321431374  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000  1.4533627244  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.5509980467  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 11:  1.9294572396175
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0000674495
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0010439412
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0031496578
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0237328573
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0290385456
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1624185084
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0703152930
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.3716184123
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.6383627097
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.7794179094
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.6733089570
+      12  L B2uAr py      0.0000000000  0.0000000000  0.0000674495  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000  0.0010439412  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  0.0031496578  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000  0.0237328573  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  0.0290385456  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000  0.1624185084  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000 -0.0703152930  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  0.3716184123  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000 -1.6383627097  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  1.7794179094  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000 -0.6733089570  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 12:  1.9294572396177
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0000389420
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0006027198
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0018184558
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0137021716
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0167654121
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0937723695
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0405965533
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.2145539904
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.9459091515
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.0273474090
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.3887351076
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0000389420  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.0006027198  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -0.0018184558  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -0.0137021716  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -0.0167654121  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.0937723695  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  0.0405965533  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -0.2145539904  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  0.9459091515  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -1.0273474090  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.3887351076  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.0000778840  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.0012054395  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -0.0036369115  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000 -0.0274043431  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -0.0335308242  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000 -0.1875447390  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000  0.0811931066  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.4291079807  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000  1.8918183030  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -2.0546948180  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000  0.7774702151  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 13:  6.6641839791637
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0002714708
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0006772421
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0114214607
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0096527177
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1496049867
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0633626083
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.8403249112
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  2.0375523857
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.8515852319
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.9326923425
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.2709422964
+      12  L B2uAr py      0.0000000000  0.0000000000  0.0002714708  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000  0.0006772421  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  0.0114214607  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000  0.0096527177  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  0.1496049867  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.0633626083  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  0.8403249112  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -2.0375523857  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  1.8515852319  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -0.9326923425  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.2709422964  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.0002714708  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.0006772421  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -0.0114214607  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000 -0.0096527177  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -0.1496049867  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  0.0633626083  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -0.8403249112  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000  2.0375523857  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -1.8515852319  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000  0.9326923425  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.2709422964  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 14:  6.6923943844479
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0002613502
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0006703852
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0136743381
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0111830043
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1831692446
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0782353555
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.0376380181
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -2.5013667043
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  2.2657884460
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.1397336606
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.3309890039
+      12  L B2uAr py      0.0000000000  0.0000000000  0.0002613502  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000  0.0006703852  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  0.0136743381  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000  0.0111830043  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  0.1831692446  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.0782353555  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  1.0376380181  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -2.5013667043  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  2.2657884460  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -1.1397336606  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.3309890039  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 15:  6.6923943844480
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0001508906
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0003870471
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0078948828
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0064565105
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1057528127
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0451692036
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.5990805891
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.4441647401
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.3081535692
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.6580255358
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1910965905
+      12  L B2uAr py      0.0000000000  0.0000000000  0.0001508906  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000  0.0003870471  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  0.0078948828  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000  0.0064565105  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  0.1057528127  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.0451692036  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  0.5990805891  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -1.4441647401  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  1.3081535692  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -0.6580255358  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.1910965905  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0003017812  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.0007740942  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  0.0157897656  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.0129130211  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000  0.2115056253  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000 -0.0903384072  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000  1.1981611782  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -2.8883294801  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000  2.6163071385  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -1.3160510716  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000  0.3821931810  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 16:  20.429059698988
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0001112532
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0049879960
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0011209217
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1207455601
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0935356062
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.2692305529
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -2.5530501435
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  2.1948715560
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.1526256110
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.4787031144
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1359484845
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0001112532  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.0049879960  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  0.0011209217  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -0.1207455601  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  0.0935356062  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -1.2692305529  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  2.5530501435  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -2.1948715560  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  1.1526256110  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -0.4787031144  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.1359484845  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0001112532  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.0049879960  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -0.0011209217  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.1207455601  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -0.0935356062  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  1.2692305529  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -2.5530501435  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000  2.1948715560  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -1.1526256110  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000  0.4787031144  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.1359484845  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 17:  20.508957935757
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0000075115
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0058373602
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0020551826
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1473029948
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1166643486
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.5632203120
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -3.1301581639
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  2.6850109129
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.4085902655
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.5848801971
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1661071351
+      12  L B2uAr py      0.0000000000  0.0000000000  0.0000075115  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000  0.0058373602  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -0.0020551826  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000  0.1473029948  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -0.1166643486  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000  1.5632203120  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000 -3.1301581639  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  2.6850109129  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000 -1.4085902655  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  0.5848801971  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000 -0.1661071351  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 18:  20.508957935758
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0000043368
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0033702015
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0011865602
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0850454237
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0673561931
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.9025256679
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.8071976586
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.5501917734
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.8132499690
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.3376807392
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0959019991
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0000043368  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.0033702015  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  0.0011865602  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -0.0850454237  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  0.0673561931  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.9025256679  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  1.8071976586  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -1.5501917734  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  0.8132499690  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -0.3376807392  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.0959019991  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.0000086736  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.0067404030  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  0.0023731204  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000 -0.1700908474  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000  0.1347123861  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000 -1.8050513358  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000  3.6143953171  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -3.1003835467  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000  1.6264999379  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.6753614785  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000  0.1918039983  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 19:  58.234850439531
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0014922533
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0030051479
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0751599245
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1161164018
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.4393900727
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  2.5352552235
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -2.2462498578
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.3309837067
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.6097723456
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.2494259586
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0717462003
+      12  L B2uAr py      0.0000000000  0.0000000000  0.0014922533  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.0030051479  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  0.0751599245  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -0.1161164018  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  1.4393900727  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -2.5352552235  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  2.2462498578  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -1.3309837067  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  0.6097723456  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -0.2494259586  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.0717462003  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.0014922533  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.0030051479  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -0.0751599245  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.1161164018  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -1.4393900727  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  2.5352552235  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -2.2462498578  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000  1.3309837067  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -0.6097723456  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000  0.2494259586  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.0717462003  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 20:  58.462454127398
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0015811615
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0042529286
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0911717853
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1452994297
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.7705754006
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  3.1061394590
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -2.7470901162
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.6266510202
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.7451172584
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.3047989310
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0876783378
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0015811615  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000  0.0042529286  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -0.0911717853  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000  0.1452994297  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -1.7705754006  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000  3.1061394590  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000 -2.7470901162  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  1.6266510202  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000 -0.7451172584  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  0.3047989310  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000 -0.0876783378  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 21:  58.462454127400
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0009128840
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0024554294
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0526380548
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0838886649
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.0222421842
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.7933304528
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.5860332181
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.9391474044
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.4301936497
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1759757449
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0506211120
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0009128840  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000  0.0024554294  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -0.0526380548  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000  0.0838886649  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -1.0222421842  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000  1.7933304528  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000 -1.5860332181  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  0.9391474044  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000 -0.4301936497  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  0.1759757449  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000 -0.0506211120  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.0018257681  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.0049108589  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -0.1052761096  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.1677773298  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -2.0444843683  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  3.5866609056  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -3.1720664362  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000  1.8782948088  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -0.8603872994  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000  0.3519514897  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.1012422239  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 22:  162.57253958612
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0011477582
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0381275597
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1095130850
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.3793013309
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  2.1782934963
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.9224493846
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.2902340560
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.7051238003
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.3211014883
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1329808637
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0386478961
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0011477582  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000  0.0381275597  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -0.1095130850  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000  1.3793013309  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -2.1782934963  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000  1.9224493846  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000 -1.2902340560  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  0.7051238003  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000 -0.3211014883  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  0.1329808637  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000 -0.0386478961  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0011477582  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.0381275597  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  0.1095130850  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000 -1.3793013309  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000  2.1782934963  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000 -1.9224493846  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000  1.2902340560  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.7051238003  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000  0.3211014883  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.1329808637  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000  0.0386478961  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 23:  163.30594729431
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0011175627
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0263925546
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0796746046
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.9791623383
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.5400534014
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.3569282055
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.9102218623
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.4974100656
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.2265236670
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0938174874
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0272668448
+      12  L B2uAr py      0.0000000000  0.0000000000  0.0011175627  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.0263925546  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  0.0796746046  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -0.9791623383  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  1.5400534014  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -1.3569282055  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  0.9102218623  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -0.4974100656  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  0.2265236670  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -0.0938174874  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.0272668448  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0022351253  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.0527851092  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  0.1593492093  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000 -1.9583246766  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000  3.0801068028  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000 -2.7138564109  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000  1.8204437245  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.9948201312  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000  0.4530473340  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.1876349748  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000  0.0545336897  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 24:  163.30594729431
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0019356753
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0457132455
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1380004633
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.6959589188
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  2.6674507376
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -2.3502685941
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.5765505116
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.8615395058
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.3923505003
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1624966548
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0472275606
+      12  L B2uAr py      0.0000000000  0.0000000000  0.0019356753  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.0457132455  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  0.1380004633  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -1.6959589188  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  2.6674507376  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -2.3502685941  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  1.5765505116  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -0.8615395058  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  0.3923505003  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -0.1624966548  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.0472275606  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 25:  469.24472431777
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0141299305
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0766064771
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.1697000906
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.6373402622
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.4213707300
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.0231268025
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.6571989014
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.3608547926
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1665297722
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0696479427
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0203519362
+      12  L B2uAr py      0.0000000000  0.0000000000  0.0141299305  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.0766064771  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  1.1697000906  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -1.6373402622  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  1.4213707300  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -1.0231268025  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  0.6571989014  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -0.3608547926  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  0.1665297722  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -0.0696479427  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.0203519362  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.0141299305  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.0766064771  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -1.1697000906  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  1.6373402622  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -1.4213707300  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  1.0231268025  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -0.6571989014  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000  0.3608547926  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -0.1665297722  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000  0.0696479427  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.0203519362  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 26:  472.18976929401
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0092016233
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0567366094
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.8302451678
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.1565632351
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.0023619665
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.7212496107
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.4632997310
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.2544098013
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1174150751
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0491086780
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0143504252
+      12  L B2uAr py      0.0000000000  0.0000000000  0.0092016233  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.0567366094  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  0.8302451678  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -1.1565632351  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  1.0023619665  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.7212496107  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  0.4632997310  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -0.2544098013  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  0.1174150751  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -0.0491086780  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.0143504252  0.0000000000
+      23  L B1uAr pz      0.0000000000  0.0184032467  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.1134732187  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  1.6604903355  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000 -2.3131264702  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000  2.0047239329  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000 -1.4424992214  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000  0.9265994619  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.5088196025  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000  0.2348301502  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.0982173559  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000  0.0287008503  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 27:  472.18976929402
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0159376791
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0982706901
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.4380268133
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  2.0032262854
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.7361418535
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.2492409706
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.8024586731
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.4406507017
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.2033688756
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0850587253
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0248556655
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0159376791  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000  0.0982706901  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -1.4380268133  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000  2.0032262854  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -1.7361418535  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000  1.2492409706  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000 -0.8024586731  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  0.4406507017  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000 -0.2033688756  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  0.0850587253  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000 -0.0248556655  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 28:  1482.8918624539
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0329765035
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.9233148809
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.0697061545
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.8884401189
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.6736018586
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.4783014456
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.3112469387
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1731279730
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0806335470
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0338931394
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0099283275
+      12  L B2uAr py      0.0000000000  0.0000000000  0.0329765035  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.9233148809  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  1.0697061545  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -0.8884401189  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  0.6736018586  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.4783014456  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  0.3112469387  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -0.1731279730  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  0.0806335470  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -0.0338931394  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.0099283275  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.0329765035  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.9233148809  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -1.0697061545  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.8884401189  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -0.6736018586  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  0.4783014456  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -0.3112469387  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000  0.1731279730  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -0.0806335470  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000  0.0338931394  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.0099283275  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 29:  1497.5953295574
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0461164105
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.1350013384
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -1.3062761340
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  1.0830665586
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.8210097675
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.5830414438
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.3794519337
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.2110835684
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0983161564
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0413268342
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0121060297
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0461164105  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000  1.1350013384  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -1.3062761340  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000  1.0830665586  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -0.8210097675  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000  0.5830414438  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000 -0.3794519337  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  0.2110835684  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000 -0.0983161564  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  0.0413268342  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000 -0.0121060297  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 30:  1497.5953295574
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0266253220
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.6552933283
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.7541788776
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.6253087691
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.4740102103
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.3366191345
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.2190766760
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1218691550
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0567628593
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0238600589
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0069894195
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.0266253220  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000  0.6552933283  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -0.7541788776  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000  0.6253087691  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -0.4740102103  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000  0.3366191345  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000 -0.2190766760  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  0.1218691550  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000 -0.0567628593  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  0.0238600589  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000 -0.0069894195  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.0532506441  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  1.3105866566  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -1.5083577552  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  1.2506175383  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -0.9480204205  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  0.6732382690  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -0.4381533521  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000  0.2437383101  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -0.1135257187  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000  0.0477201177  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.0139788390  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 31:  5631.7219253246
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.7133015442
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.5675558182
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.4301019394
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.3347372658
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.2567416647
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1855658932
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1222423131
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0684859445
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0320315335
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0134921313
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0039560731
+      12  L B2uAr py      0.0000000000  0.0000000000  0.7133015442  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.5675558182  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  0.4301019394  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -0.3347372658  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  0.2567416647  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.1855658932  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  0.1222423131  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -0.0684859445  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  0.0320315335  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -0.0134921313  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.0039560731  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.7133015442  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000  0.5675558182  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000 -0.4301019394  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000  0.3347372658  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000 -0.2567416647  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000  0.1855658932  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -0.1222423131  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000  0.0684859445  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000 -0.0320315335  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000  0.0134921313  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.0039560731  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 32:  5757.7286886750
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.5042313575
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.3970533650
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.3005775962
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.2340345061
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1795752092
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.1298233266
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0855329492
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0479229677
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0224148995
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0094416442
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0027684390
+      12  L B2uAr py      0.0000000000  0.0000000000  0.5042313575  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000 -0.3970533650  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000  0.3005775962  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000 -0.2340345061  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000  0.1795752092  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000 -0.1298233266  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000  0.0855329492  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000 -0.0479229677  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000  0.0224148995  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000 -0.0094416442  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000  0.0027684390  0.0000000000
+      23  L B1uAr pz      0.0000000000  1.0084627149  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.7941067300  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  0.6011551924  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000 -0.4680690122  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000  0.3591504184  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000 -0.2596466533  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000  0.1710658983  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.0958459354  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000  0.0448297990  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.0188832884  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000  0.0055368781  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 33:  5757.7286886750
+====================================================
+       1  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.8733543299
+       2  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.6877166015
+       3  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.5206156682
+       4  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.4053596553
+       5  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.3110333861
+       6  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.2248605977
+       7  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.1481474137
+       8  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0830050149
+       9  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0388237448
+      10  L B3uAr px      0.0000000000  0.0000000000  0.0000000000  0.0163534074
+      11  L B3uAr px      0.0000000000  0.0000000000  0.0000000000 -0.0047950771
+      12  L B2uAr py      0.0000000000  0.0000000000 -0.8733543299  0.0000000000
+      13  L B2uAr py      0.0000000000  0.0000000000  0.6877166015  0.0000000000
+      14  L B2uAr py      0.0000000000  0.0000000000 -0.5206156682  0.0000000000
+      15  L B2uAr py      0.0000000000  0.0000000000  0.4053596553  0.0000000000
+      16  L B2uAr py      0.0000000000  0.0000000000 -0.3110333861  0.0000000000
+      17  L B2uAr py      0.0000000000  0.0000000000  0.2248605977  0.0000000000
+      18  L B2uAr py      0.0000000000  0.0000000000 -0.1481474137  0.0000000000
+      19  L B2uAr py      0.0000000000  0.0000000000  0.0830050149  0.0000000000
+      20  L B2uAr py      0.0000000000  0.0000000000 -0.0388237448  0.0000000000
+      21  L B2uAr py      0.0000000000  0.0000000000  0.0163534074  0.0000000000
+      22  L B2uAr py      0.0000000000  0.0000000000 -0.0047950771  0.0000000000
+      23  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      24  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      25  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      26  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      27  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      28  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      29  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      30  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      31  L B1uAr pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      32  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+      33  L B1uAr pz      0.0000000000 -0.0000000000  0.0000000000  0.0000000000
+
+
+    **************************************************************************
+    ********************** Mulliken population analysis **********************
+    **************************************************************************
+
+
+
+                                Fermion ircop E1g
+                                -----------------
+
+
+
+                                Fermion ircop E1g
+                                -----------------
+
+
+* Electronic eigenvalue no.   1: -119.08976515605   (Occupation : f = 1.0000)  s 1/2;  1/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L Ag Ar s   
+--------------------------------------
+ alpha    1.0000  |      1.0000
+ beta     0.0000  |      0.0000
+
+* Electronic eigenvalue no.   2: -12.408715632851   (Occupation : f = 1.0000)  s 1/2;  1/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L Ag Ar s   
+--------------------------------------
+ alpha    1.0000  |      1.0000
+ beta     0.0000  |      0.0000
+
+* Electronic eigenvalue no.   3: -1.2861708364985   (Occupation : f = 1.0000)  s 1/2;  1/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L Ag Ar s   
+--------------------------------------
+ alpha    1.0000  |      1.0000
+ beta     0.0000  |      0.0000
+
+
+** Total gross population of fermion ircop E1g **
+
+Gross      Total    |    L Ag Ar s   
+--------------------------------------
+ total     6.00000  |      6.00000
+
+
+                                Fermion ircop E1u
+                                -----------------
+
+
+
+                                Fermion ircop E1u
+                                -----------------
+
+
+* Electronic eigenvalue no.   1: -9.6307690617900   (Occupation : f = 1.0000)  p 1/2;  1/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz  
+--------------------------------------------------------------------
+ alpha    0.3333  |      0.0000         0.0000         0.3333
+ beta     0.6667  |      0.3333         0.3333         0.0000
+
+* Electronic eigenvalue no.   2: -9.5459312905742   (Occupation : f = 1.0000)  p 3/2; -3/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L B3uAr px     L B2uAr py  
+-----------------------------------------------------
+ alpha    0.0000  |      0.0000         0.0000
+ beta     1.0000  |      0.5000         0.5000
+
+* Electronic eigenvalue no.   3: -9.5459312905741   (Occupation : f = 1.0000)  p 3/2;  1/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz  
+--------------------------------------------------------------------
+ alpha    0.6667  |      0.0000         0.0000         0.6667
+ beta     0.3333  |      0.1667         0.1667         0.0000
+
+* Electronic eigenvalue no.   4: -0.5951735375871   (Occupation : f = 1.0000)  p 1/2;  1/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz  
+--------------------------------------------------------------------
+ alpha    0.3333  |      0.0000         0.0000         0.3333
+ beta     0.6667  |      0.3333         0.3333         0.0000
+
+* Electronic eigenvalue no.   5: -0.5876208934851   (Occupation : f = 1.0000)  p 3/2;  1/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz  
+--------------------------------------------------------------------
+ alpha    0.6667  |      0.0000         0.0000         0.6667
+ beta     0.3333  |      0.1667         0.1667         0.0000
+
+* Electronic eigenvalue no.   6: -0.5876208934848   (Occupation : f = 1.0000)  p 3/2; -3/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L B3uAr px     L B2uAr py  
+-----------------------------------------------------
+ alpha    0.0000  |      0.0000         0.0000
+ beta     1.0000  |      0.5000         0.5000
+
+
+** Total gross population of fermion ircop E1u **
+
+Gross      Total    |    L B3uAr px     L B2uAr py     L B1uAr pz  
+--------------------------------------------------------------------
+ total    12.00000  |      4.00000        4.00000        4.00000
+
+
+*** Total gross population ***
+
+Gross      Total    |    L Ag Ar s      L B3uAr px     L B2uAr py     L B1uAr pz  
+-----------------------------------------------------------------------------------
+ total    18.00000  |      6.00000        4.00000        4.00000        4.00000
+===========================================================================
+* PCMOUT: Coefficients read from unformatted DFCOEF 
+          and written to formatted DFPCMO
+===========================================================================
+
+
+    **************************************************************************
+    **************** Transformation to Molecular Spinor Basis ****************
+    **************************************************************************
+
+
+          Written by Luuk Visscher, Jon Laerdahl & Trond Saue
+          Odense, 1997
+
+
+
+
+     ************************************************************************
+     **************** Transformation of 2-electron integrals ****************
+     ************************************************************************
+
+
+ Transformation started at : Wed Nov  9 13:20:52 2022
+
+* REACMO: Coefficients read from file DFCOEF - Total energy: -528.633321041667273
+* Heading :Ar                                                Wed Nov  9 13:20:52 2022
+
+* Orbital ranges for 4-index transformation:
+
+
+ * Fermion ircop E1g
+
+      Index 1   33 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15   16   17   18   19   20   21   22   23   24
+         25   26   27   28   29   30   31   32   33
+
+      Index 2   33 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15   16   17   18   19   20   21   22   23   24
+         25   26   27   28   29   30   31   32   33
+
+      Index 3   33 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15   16   17   18   19   20   21   22   23   24
+         25   26   27   28   29   30   31   32   33
+
+      Index 4   33 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15   16   17   18   19   20   21   22   23   24
+         25   26   27   28   29   30   31   32   33
+
+
+ * Fermion ircop E1u
+
+      Index 1   33 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15   16   17   18   19   20   21   22   23   24
+         25   26   27   28   29   30   31   32   33
+
+      Index 2   33 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15   16   17   18   19   20   21   22   23   24
+         25   26   27   28   29   30   31   32   33
+
+      Index 3   33 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15   16   17   18   19   20   21   22   23   24
+         25   26   27   28   29   30   31   32   33
+
+      Index 4   33 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15   16   17   18   19   20   21   22   23   24
+         25   26   27   28   29   30   31   32   33
+
+ (PAMTRA)  Orbitals read from DFCOEF
+
+* Core orbital ranges for 2-index transformation:
+
+
+ * Fermion ircop E1g
+
+      No orbitals for index 1
+
+
+ * Fermion ircop E1u
+
+      No orbitals for index 1
+
+
+    **************************************************************************
+    **************** Transformation to Molecular Spinor Basis ****************
+    **************************************************************************
+
+
+          Written by Luuk Visscher, Jon Laerdahl & Trond Saue
+          Odense, 1997
+
+
+
+
+      **********************************************************************
+      **************** Transformation of property integrals ****************
+      **********************************************************************
+
+
+ Transformation started at : Wed Nov  9 13:20:52 2022
+
+* REACMO: Coefficients read from file DFCOEF - Total energy: -528.633321041667273
+* Heading :Ar                                                Wed Nov  9 13:20:52 2022
+
+
+ * Fermion ircop E1g
+
+      Index 1   33 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15   16   17   18   19   20   21   22   23   24
+         25   26   27   28   29   30   31   32   33
+
+      Index 2   33 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15   16   17   18   19   20   21   22   23   24
+         25   26   27   28   29   30   31   32   33
+
+
+ * Fermion ircop E1u
+
+      Index 1   33 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15   16   17   18   19   20   21   22   23   24
+         25   26   27   28   29   30   31   32   33
+
+      Index 2   33 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15   16   17   18   19   20   21   22   23   24
+         25   26   27   28   29   30   31   32   33
+
+
+    **************************************************************************
+    **************** Transformation to Molecular Spinor Basis ****************
+    **************************************************************************
+
+
+          Written by Luuk Visscher, Jon Laerdahl & Trond Saue
+          Odense, 1997
+
+
+
+
+       ********************************************************************
+       **************** Transformation of core Fock matrix ****************
+       ********************************************************************
+
+
+ Transformation started at : Wed Nov  9 13:20:52 2022
+
+* REACMO: Coefficients read from file DFCOEF - Total energy: -528.633321041667273
+* Heading :Ar                                                Wed Nov  9 13:20:52 2022
+
+* REAFCK: Fock matrix read from file /home/noda/DIRAC_scratch_directory/noda/DIRAC_Ar_Ar_3882108/
+* Heading :Ar                                                Wed Nov  9 13:20:52 2022
+
+
+ Core energy (includes nuclear repulsion) :              0.0000000000
+ - Electronic part :                                     0.0000000000
+   - One-electron terms :                                0.0000000000
+   - Two-electron terms :                                0.0000000000
+
+
+ MOLFDIR file MRCONEE is written
+
+ * Max no. of B shells in a task determined to be   4
+ - Integral class 2 : (SS|??)
+ - Integral class 1 : (LL|??)
+   - Starting shell A no.    5 after           0.00 seconds.
+   - Starting shell A no.    4 after           0.00 seconds.
+   - Starting shell A no.    3 after           0.00 seconds.
+   - Starting shell A no.    2 after           0.14 seconds.
+   - Starting shell A no.    1 after           0.18 seconds.
+ Node    2 finished first half transformation         1185633 HT integrals written ( 66.47%,      0.03 GB)
+ Node    3 finished first half transformation          962856 HT integrals written ( 66.98%,      0.02 GB)
+ Node    1 finished first half transformation         1359766 HT integrals written ( 66.70%,      0.03 GB)
+
+
+   Integrals written :
+
+
+   Integrals written :
+
+
+   Integrals written :
+
+
+   Integrals written :
+ >>> CPU time used in 2HT_all is   2.24 seconds
+ >>> CPU time used in 2HT_all is   2.24 seconds
+ >>> CPU time used in 2HT_all is   2.27 seconds
+ >>> CPU time used in 2HT_all is   2.29 seconds
+ - Binary  file MDCINT was written.
+* Screening statistics:
+   (LL|LL)ints :   0.00%
+   Total       :   0.00%
+
+------ Timing report (in CPU seconds) of module  integral transformation      
+
+
+
+                                    Master   --------- Slaves ------------
+
+ Timer                              Master   Minimum   Maximum     Average
+
+  First halftransformation             1.1       1.1       1.1       1.1
+  Slave requesting task from ma        0.2       0.0       0.0       0.0
+  Master and slave negotiating         0.0       0.0       0.0       0.0
+  Second halftransformation            2.3       2.2       2.3       2.2
+
+------ End of timing report ------
+
+
+
+ Total wall time used in PAMTRA :   00:00:04
+ Total CPU  time used in PAMTRA (master only) :   00:00:04
+
+ Transformation ended at : Wed Nov  9 13:20:56 2022
+
+
+---< Process     1 of     4----<
+
+
+
+ Relativistic Coupled Cluster program RELCCSD
+
+ Written by :
+    Lucas Visscher
+
+    NASA Ames Research Center    (1994)
+    Rijks Universiteit Groningen (1995)
+    Odense Universitet           (1996-1997)
+    VU University Amsterdam      (1998-present)
+
+
+ This module is documented in
+  - Initial implementation : L. Visscher, T.J. Lee and K.G. Dyall, J. Chem. Phys. 105 (1996) 8769.
+  - Fock Space (FSCC)      : L. Visscher, E. Eliav and U. Kaldor, J. Chem. Phys. 115 (2002) 9720.
+  - Parallelization        : M. Pernpointner and L. Visscher, J. Comp. Chem. 24 (2003) 754.
+  - Intermediate Hamilt. FS: E. Eliav, M. J. Vilkas, Y. Ishikawa, and U. Kaldor, J. Chem. Phys. 122 (2005) 224113.
+  - MP2 expectation values : J.N.P. van Stralen, L. Visscher, C.V. Larsen and H.J.Aa. Jensen," Chem. Phys. 311 (2005) 81.
+  - CC  expectation values : A. Shee, L. Visscher, and T. Saue, J. Chem. Phys. 145 (2016) 184107.
+  - EOM-IP/EA/EE energies  : A. Shee, T. Saue, L. Visscher, and A.S.P. Gomes, J. Chem. Phys. 149 (2018) 174113.
+  - Core spectra (CVS-EOM) : L. Halbert, M. L. Vidal, A. Shee, S. Coriani, and A.S.P. Gomes, arXiv:2011.08549
+
+
+ Today is :     9 Nov 22
+ The time is :  13:20:56
+
+ Initializing word-addressable I/O : the FORTRAN-interface is used with    16 KB records
+===========================================================================
+ **RELCC: Set-up for Coupled Cluster calculations
+===========================================================================
+ * General print level   :   0
+
+ Total memory available :       16384.00 MB   16.000 GB
+ 
+ INFO: No old restart file(s) found!
+ 
+
+ Configuration in highest pointgroup
+
+                                          Eg   Eg   Eu   Eu
+ Spinor class : occupied                   3    3    6    6
+ Spinor class : virtual                   30   30   27   27
+
+ Configuration in abelian subgroup
+
+                                          1g  -1g   3g  -3g   5g  -5g   1u  -1u
+ Spinor class : occupied                   3    3    0    0    0    0    4    4
+ Spinor class : virtual                   21   21    6    6    3    3   18   18
+
+ Configuration in abelian subgroup
+
+                                          3u  -3u
+ Spinor class : occupied                   2    2
+ Spinor class : virtual                    9    9
+
+
+ Number of electrons :                    18
+ Total charge of the system :              0
+ Number of virtual spinors :             114
+ Complex arithmetic mode :                 F
+ Do integral sorting     :                 T
+ Do energy calculation   :                 T
+ Do gradient calculation :                 F
+ Do response calculation :                 F
+ Debug information       :                 F
+ Timing information      :                 F
+ Print level          :                    0
+ Memory limit (MWord) :                      2048
+ Interface used       :                DIRAC6    
+
+
+ Leave after calculating the total memory demand :          F
+ Memory for reading and sorting integrals :             10264364 8-byte words
+ Core used for calculating amplitudes :                  2337442 8-byte words
+ Core used for in core evaluation of triples :           1449310 8-byte words
+ Memory used for active modules :                       10264364 8-byte words
+
+ Predicted RelCC memory demand:           78.31 MB
+ Predicted RelCC memory demand:           0.076 GB
+
+ Expanding and sorting integrals to unique types :
+ Type OOOO :            2845 integrals
+ Type VOOO :           35154 integrals
+ Type VVOO :          104649 integrals
+ Type VOVO :          441558 integrals
+ Type VOVV :         1320516 integrals
+ Type VVVV :         3965355 integrals
+ 
+ Start sorting of integral classes at   9 Nov 22 13:20:56
+ 
+ 
+ Sorting of first 4 classes done at   9 Nov 22 13:20:57
+
+ Need      1 passes to sort VOVV integrals
+ 
+ Pass     1 ended at   9 Nov 22 13:20:59
+ 
+ VOVV sorting done at   9 Nov 22 13:20:59
+
+ Need      1 passes to sort VVVV integrals
+ 
+ Pass     1 ended at   9 Nov 22 13:21:00
+ 
+ VVVV sorting done at   9 Nov 22 13:21:00
+
+ Reading Coulomb integrals :
+ File date :       9 Nov 22
+ File time :       13:21:00
+ # of integrals            10834180
+
+ Finished sorting of integrals
+
+
+ Single determinant electronic energy :     -528.633321041711156
+
+
+ Checking the orbital energies, the program computes the diagonal elements of the
+ reconstructed Fock matrix. Differences with the reference orbital energies
+ are given if above a treshold or if iprnt > 1
+
+ Spinor   Abelian Rep.         Energy   Recalc. Energy
+  O    2    2    1g      -12.4087156329  -12.4087184743
+  O    3    3    1g       -1.2861708365   -1.2861719920
+  O    2    5   -1g      -12.4087156329  -12.4087184743
+  O    3    6   -1g       -1.2861708365   -1.2861719920
+  O    1    7    1u       -9.6307690618   -9.6307719418
+  O    2    8    1u       -9.5459312906   -9.5459342760
+  O    3    9    1u       -0.5951735376   -0.5951744778
+  O    4   10    1u       -0.5876208935   -0.5876221229
+  O    1   11   -1u       -9.6307690618   -9.6307719418
+  O    2   12   -1u       -9.5459312906   -9.5459342760
+  O    3   13   -1u       -0.5951735376   -0.5951744778
+  O    4   14   -1u       -0.5876208935   -0.5876221229
+  O    1   15    3u       -9.5459312906   -9.5459342760
+  O    2   16    3u       -0.5876208935   -0.5876221229
+  O    1   17   -3u       -9.5459312906   -9.5459342760
+  O    2   18   -3u       -0.5876208935   -0.5876221229
+  V    1   19    1g        0.4340708135    0.4340703816
+  V    2   20    1g        0.6799253018    0.6799242758
+  V    3   21    1g        0.6800780647    0.6800770182
+  V    4   22    1g        2.4709748123    2.4709732803
+  V    5   23    1g        2.4717998157    2.4717982209
+  V    6   24    1g        2.4845431715    2.4845420701
+  V    7   25    1g        7.3660741088    7.3660720228
+  V    8   26    1g        7.3680616158    7.3680595156
+  V    9   27    1g        9.7193638313    9.7193617944
+  V    1   40   -1g        0.4340708135    0.4340703816
+  V    2   41   -1g        0.6799253018    0.6799242758
+  V    3   42   -1g        0.6800780647    0.6800770182
+  V    4   43   -1g        2.4709748123    2.4709732803
+  V    5   44   -1g        2.4717998157    2.4717982209
+  V    6   45   -1g        2.4845431715    2.4845420701
+  V    7   46   -1g        7.3660741088    7.3660720228
+  V    8   47   -1g        7.3680616158    7.3680595156
+  V    9   48   -1g        9.7193638313    9.7193617944
+  V    1   61    3g        0.6799253018    0.6799242758
+  V    2   62    3g        0.6800780647    0.6800770182
+  V    3   63    3g        2.4709748123    2.4709732803
+  V    4   64    3g        2.4717998157    2.4717982209
+  V    5   65    3g        7.3660741088    7.3660720228
+  V    6   66    3g        7.3680616158    7.3680595156
+  V    1   67   -3g        0.6799253018    0.6799242758
+  V    2   68   -3g        0.6800780647    0.6800770182
+  V    3   69   -3g        2.4709748123    2.4709732803
+  V    4   70   -3g        2.4717998157    2.4717982209
+  V    5   71   -3g        7.3660741088    7.3660720228
+  V    6   72   -3g        7.3680616158    7.3680595156
+  V    1   73    5g        0.6800780647    0.6800770182
+  V    2   74    5g        2.4717998157    2.4717982209
+  V    3   75    5g        7.3680616158    7.3680595156
+  V    1   76   -5g        0.6800780647    0.6800770182
+  V    2   77   -5g        2.4717998157    2.4717982209
+  V    3   78   -5g        7.3680616158    7.3680595156
+  V    1   79    1u        0.4024736817    0.4024734745
+  V    2   80    1u        0.4046413928    0.4046410895
+  V    3   81    1u        1.9203990692    1.9203981507
+  V    4   82    1u        1.9294572396    1.9294561988
+  V    5   83    1u        6.6641839792    6.6641821708
+  V    6   84    1u        6.6923943844    6.6923924964
+  V    7   85    1u       20.4290596990   20.4290572047
+  V    8   86    1u       20.5089579358   20.5089553896
+  V    1   97   -1u        0.4024736817    0.4024734745
+  V    2   98   -1u        0.4046413928    0.4046410895
+  V    3   99   -1u        1.9203990692    1.9203981507
+  V    4  100   -1u        1.9294572396    1.9294561988
+  V    5  101   -1u        6.6641839792    6.6641821708
+  V    6  102   -1u        6.6923943844    6.6923924964
+  V    7  103   -1u       20.4290596990   20.4290572047
+  V    8  104   -1u       20.5089579358   20.5089553896
+  V    1  115    3u        0.4046413928    0.4046410895
+  V    2  116    3u        1.9294572396    1.9294561988
+  V    3  117    3u        6.6923943844    6.6923924964
+  V    4  118    3u       20.5089579358   20.5089553896
+  V    1  124   -3u        0.4046413928    0.4046410895
+  V    2  125   -3u        1.9294572396    1.9294561988
+  V    3  126   -3u        6.6923943844    6.6923924964
+  V    4  127   -3u       20.5089579358   20.5089553896
+
+ The diagonal elements of the recomputed Fock matrix (right column) are used in perturbation expressions.
+
+ Use the perturbative values (MP2, CCSD[T]/(T)/-T) with care, especially
+ in  open shell calculations because the orbitals need not always be
+ semi-canonical as was assumed in the derivation of the expressions.
+ The missing terms may be important !
+
+
+ Nuclear repulsion + core energy :             0.000000000000000
+ Zero order electronic energy :             -326.555436409485310
+ First order electronic energy :            -202.077884632225846
+ Electronic energy :                        -528.633321041711156
+ SCF energy :                               -528.633321041711156
+
+
+ Energy calculations
+ MP2 module active :                       T
+ CCSD module active :                      T
+ CCSD(T) module active :                   T
+
+
+  MP2 results
+
+ SCF energy :                               -528.633321041711156
+ MP2 correlation energy :                     -0.386446035446686
+ Total MP2 energy :                         -529.019767077157894
+ T1 diagnostic :                               0.000000184584995
+
+
+ CCSD options :
+ Maximum number of iterations :           30
+ Maximum size of DIIS space :              8
+ Convergence criterium :             0.1E-11
+
+
+  CCSD results
+
+ SCF energy :                               -528.633321041711156
+ CCSD correlation energy :                    -0.395346344355252
+ Total CCSD energy :                        -529.028667386066445
+ T1 diagnostic :                               0.002883931074638
+ Convergence :                                 0.000000000000533
+ Number or iterations used :                                  12
+
+
+  Perturbative treatment of triple excitations
+
+ SCF energy :                               -528.633321041711156
+ CCSD correlation energy :                    -0.395346344355252
+ 4th order triples correction :               -0.005240151319823
+ 5th order triples (T) correction :            0.000048979972326
+ 5th order triples -T  correction :            0.000074494729649
+ Total CCSD+T  energy :                     -529.033907537386312
+ Total CCSD(T) energy :                     -529.033858557413964
+ Total CCSD-T  energy :                     -529.033833042656624
+
+
+--------------------------------------------------------------------------------
+
+
+ Today is :     9 Nov 22
+ The time is :  13:21:02
+
+ Status of the calculations
+ Integral sort # 1 :                   Completed, restartable        
+ Integral sort # 2 :                   Completed, restartable        
+ Fock matrix build :                   Completed, restartable        
+ MP2 energy calculation :              Completed, restartable        
+ CCSD energy calculation :             Completed, restartable        
+ CCSD(T) energy calculation :          Completed, restartable        
+ CCSD(T) energy calculation :          Completed, restartable        
+
+ Overview of calculated energies
+@ SCF energy :                              -528.633321041711156
+@ MP2 correlation energy :                    -0.386446035446686
+@ CCSD correlation energy :                   -0.395346344355252
+@ 4th order triples correction :              -0.005240151319823
+@ 5th order triples (T) correction :           0.000048979972326
+@ 5th order triples -T  correction :           0.000074494729649
+@ Total MP2 energy :                        -529.019767077157894
+@ Total CCSD energy :                       -529.028667386066445
+@ Total CCSD+T  energy :                    -529.033907537386312
+@ Total CCSD(T) energy :                    -529.033858557413964
+@ Total CCSD-T  energy :                    -529.033833042656624
+
+
+--------------------------------------------------------------------------------
+
+------ Timing report (in CPU seconds) of module  RELCCSD                      
+
+
+
+                                    Master   --------- Slaves ------------
+
+ Timer                              Master   Minimum   Maximum     Average
+
+ Sorting of integrals                  4.2       4.2       4.2       4.2
+ CCSD equations                        0.6       0.6       0.6       0.6
+ - T1 equations                        0.1       0.1       0.1       0.1
+ --- T1EQNS T*[HOV - F]*T              0.0       0.0       0.0       0.0
+ --- T1EQNS HOV*T2(A,C,I,K             0.0       0.0       0.0       0.0
+ --- T1EQNS   HV*T / T*HO              0.0       0.0       0.0       0.0
+ --- T1EQNS VOOO*TAU                   0.0       0.0       0.0       0.0
+ --- T1EQNS VOVV contribution          0.0       0.0       0.0       0.0
+ --- T1EQNS VOVO * T(C,K)              0.0       0.0       0.0       0.0
+ -- GOINTM                             0.0       0.0       0.0       0.0
+ -- GVINTM                             0.0       0.0       0.0       0.0
+ -- AINTM                              0.0       0.0       0.0       0.0
+ -- HINTM                              0.2       0.2       0.2       0.2
+ --- HINTM: VOVV*T                     0.0       0.0       0.0       0.0
+ --- HINTM: VVOO contribution          0.0       0.0       0.0       0.0
+ -- combining HINTM via MPI_ALL        0.1       0.1       0.1       0.1
+ -- T2 EQNS                            0.2       0.2       0.2       0.2
+ --- T2EQNS: TAU*AINTM contract        0.0       0.0       0.0       0.0
+ --- T2EQNS: VOVV*T1                   0.0       0.0       0.0       0.0
+ --- T2EQNS: HINTM*T2                  0.0       0.1       0.1       0.1
+ -- BINTM                              0.1       0.1       0.1       0.1
+ - adding partial T1/T2 amplitu        0.0       0.0       0.0       0.0
+ - DIIS extrapolation                  0.1       0.0       0.0       0.0
+ - synchronizing T1 & T2 amplit        0.0       0.1       0.1       0.1
+ CCSD(T) evaluation                    1.0       1.0       1.0       1.0
+ -- T3CORR: Integral resorting         0.0       0.0       0.0       0.0
+ -- T3CORR: VOVV contraction           0.2       0.1       0.1       0.1
+ -- T3CORR: addition of partial        0.4       0.7       0.7       0.7
+ -- T3CORR: energy calculation         0.3       0.0       0.0       0.0
+
+------ End of timing report ------
+
+
+
+ Timing of main modules :         Wallclock (s)       CPU on master (s)
+ Before CC driver :          ************                     4.17
+ Initialization :                    0.07                     0.07
+ Integral sorting :                  4.19                     4.17
+ Energy calculation :                1.62                     1.61
+ First order properties :            0.00                     0.00
+ Second order properties :           0.00                     0.00
+ Fock space energies :               0.00                     0.00
+ EOMCC energies :                    0.00                     0.00
+ Untimed parts :                     0.00                     0.00
+ Total time in CC driver :             6.                     5.86
+
+ Statistics for the word-addressable I/O
+ Number of write calls                                1674.
+ Number of read calls                                 1692.
+ Megabytes written                                   22.077
+ Megabytes read                                     287.034
+ Seconds spent in reads                               0.142
+ Seconds spent in writes                              0.143
+ average I/O speed for write (Mb/s)                 155.673
+ average I/O speed for read  (Mb/s)                2011.123
+
+
+ CPU time (seconds) used in RELCCSD:                     5.8565
+ CPU time (seconds) used before RELCCSD:                 4.1701
+ CPU time (seconds) used in total sofar:                10.0266
+
+  --- Normal end of RELCCSD Run ---
+
+
+################################################################################
+
+
+       *******************************************************************
+       ************************* Property module *************************
+       *******************************************************************
+
+
+
+   This is output from the Dirac property module:
+
+   * HF & DFT first order properties
+      Trond Saue
+
+   * First-order ESR properties
+      Hans Joergen Aa. Jensen et al.
+
+   * MP2 first order properties:
+      J. N. P. van Stralen, L. Visscher, C. V. Larsen and H. J. Aa Jensen, Chem. Phys. 311 (2005) 81.
+
+   * KR-RPA second-order properties
+      Hans Joergen Aa. Jensen and Trond Saue
+
+   * KR-QR third order properties
+      Patrick Norman and Hans Joergen Aa. Jensen
+
+   * Oscillator strengths beyond the electric dipole approximation
+      N.H. List, T.R.L Melin, M. van Horn, T. Saue, J. Chem. Phys. 152 (2020) 184110
+
+   * Molecular gradient
+      Joern Thyssen
+
+   * Additional contributions from:
+      Thomas Enevoldsen, Miroslav Ilias (London orbitals)
+
+
+
+
+             *******************************************************
+             ********** Properties for DHF  wave function **********
+             *******************************************************
+
+
+
+    **************************************************************************
+    *************************** Expectation values ***************************
+    **************************************************************************
+
+    Rho at nuc Ar 01 :     4243.659210628 a.u.      s0 = F   t0 = F
+    ---------------------------------------------------------------------------
+    s0 = T : Expectation value zero by point group symmetry.
+    t0 = T : Expectation value zero by time reversal symmetry.
+----------------------------------------------------------------------------
+
+*****************************************************
+********** E N D   of   D I R A C  output  **********
+*****************************************************
+
+
+ 
+     Date and time (Linux)  : Wed Nov  9 13:21:04 2022
+     Host name              : relqc01                                 
+
+>>>> Node 0, utime: 9, stime: 2, minflt: 23245, majflt: 38, nvcsw: 723, nivcsw: 448, maxrss: 181472
+>>>> Total WALL time used in DIRAC: 13s
+  
+  Dynamical Memory Usage Summary for Master
+  
+  Mean allocation size (Mb) :        27.62
+  
+  Largest                    10  allocations
+  
+      488.28 Mb at subroutine pamprp_1_+0xa9                             for WORK in PAMPRP_1                          
+      488.28 Mb at subroutine pamtra_+0x134                              for WORK in PAMTRA                            
+      488.28 Mb at subroutine pamana_+0x89                               for WORK in PAMANA                            
+      488.28 Mb at subroutine psiscf_+0x99                               for WORK in PSISCF                            
+      488.28 Mb at subroutine pamset_+0x336                              for WORK in PAMSET - 2                        
+      488.28 Mb at subroutine gmotra_+0x42e0                             for WORK in GMOTRA - part 2                   
+      488.28 Mb at subroutine gmotra_+0x4cd8                             for WORK in GMOTRA                            
+      488.28 Mb at subroutine pamset_+0x86                               for WORK in PAMSET - 1                        
+      488.28 Mb at subroutine MAIN__+0x9be                               for test allocation of work array in DIRAC mai
+       30.28 Mb at subroutine ccseti_+0x6f9                              for vta                                       
+  
+  Peak memory usage:       488.32 MB
+  Peak memory usage:        0.477 GB
+       reached at subroutine : butobs_no_work_+0x79                      
+              for variable   : buf in butobs                             
+  
+ MEMGET high-water mark:     0.00 MB
+
+*****************************************************
+DIRAC pam run in /home/noda/debug_run/Ar/ras28/vecpri
+
+ ====  below this line is the stderr stream  ====
+--------------------------------------------------------------------------
+[[61273,1],0]: A high-performance Open MPI point-to-point messaging module
+was unable to find any relevant network interfaces:
+
+Module: OpenFabrics (openib)
+  Host: relqc01
+
+Another transport will be used instead, although this may result in
+lower performance.
+
+NOTE: You can disable this warning by setting the MCA parameter
+btl_base_warn_component_unused to 0.
+--------------------------------------------------------------------------
+[relqc01:3882148] ../../../../../ompi/mca/pml/ucx/pml_ucx.c:206 Error: Failed to create UCP worker
+[relqc01:3882146] ../../../../../ompi/mca/pml/ucx/pml_ucx.c:206 Error: Failed to create UCP worker
+[relqc01:3882149] ../../../../../ompi/mca/pml/ucx/pml_ucx.c:206 Error: Failed to create UCP worker
+[relqc01:3882147] ../../../../../ompi/mca/pml/ucx/pml_ucx.c:206 Error: Failed to create UCP worker
+[relqc01:3882141] 3 more processes have sent help message help-mpi-btl-base.txt / btl:no-nics
+[relqc01:3882141] Set MCA parameter "orte_base_help_aggregate" to 0 to see all help / error messages

--- a/main.py
+++ b/main.py
@@ -1,9 +1,9 @@
 import os
 import subprocess
 import sys
-from PySide6.QtCore import Qt, Signal
-from PySide6.QtGui import QAction, QDragEnterEvent, QScreen
-from PySide6.QtWidgets import (
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtGui import QAction, QDragEnterEvent, QScreen
+from qtpy.QtWidgets import (
     QApplication,
     QMainWindow,
     QTableWidget,

--- a/main.py
+++ b/main.py
@@ -172,7 +172,7 @@ class MainWindow(QMainWindow):
         self.open_action_dirac = QAction("Open with DIRAC output", self)
         self.open_action_dirac.triggered.connect(self.selectFileDirac)
         self.file_menu.addAction(self.open_action_dirac)
-        self.open_action_dfcoef = QAction("Open with sum_dirac_dfcoef", self)
+        self.open_action_dfcoef = QAction("Open with sum_dirac_dfcoef output", self)
         self.open_action_dfcoef.triggered.connect(self.selectFileDFCOEF)
         self.file_menu.addAction(self.open_action_dfcoef)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+Pyside6
+qtpy
 sum-dirac-dfcoef


### PR DESCRIPTION
- Fix sum_dirac_dfcoef command
- Import qtpy package instead of Pyside6
- Add Pyside6 and qtpy packages to requirements.txt
- Add feature to open with sum_dirac_dfcoef output option